### PR TITLE
Fixing Docker Images Tags for Main Merges

### DIFF
--- a/.github/workflows/docker_main.yml
+++ b/.github/workflows/docker_main.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set build tag
         id: build_tag_generator
         run: |
-          RELEASE_TAG=$(curl https://api.github.com/repos/hyperledger/firefly-tokens-erc20/releases/latest -s | jq .tag_name -r)
+          RELEASE_TAG=$(curl https://api.github.com/repos/hyperledger/firefly-tokens-erc20-erc721/releases/latest -s | jq .tag_name -r)
           BUILD_TAG=$RELEASE_TAG-$(date +"%Y%m%d")-$GITHUB_RUN_NUMBER
           echo ::set-output name=BUILD_TAG::$BUILD_TAG
 


### PR DESCRIPTION
NOTE: this does _not_ update the workflow to publish new images to the `firefly-tokens-erc20-erc-721` image URI yet. Saving that for a future migration. This is just to fix the image tagging issue we are seeing where tags start with `null` rather than `v0.1.2`