### PR TITLE
Fixing Readiness Endpoint Check

### DIFF
--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -23,8 +23,8 @@ export class HealthController {
     return this.health.check([
       () =>
         this.http.pingCheck(
-          'ethconnect-contract',
-          this.tokensService.baseUrl,
+          'ethconnect',
+          `${this.tokensService.baseUrl}/status`,
           basicAuth(this.tokensService.username, this.tokensService.password),
         ),
     ]);


### PR DESCRIPTION
Ethconnect returns `Method Not Allowed` for its root `/` URI. The `/status` endpoint is ideal since it works with Ethconnects in either local or remote mode since the connector config is now stateless and unaware of specific contract deployments.