### PR TITLE
Verify that name/symbol match the deployed contract

### DIFF
--- a/src/request-logging.interceptor.ts
+++ b/src/request-logging.interceptor.ts
@@ -46,7 +46,7 @@ export class RequestLoggingInterceptor implements NestInterceptor {
           const statusMessage = httpError.message;
           this.logResponse(request, statusCode, statusMessage);
         }
-        return throwError(() => new Error(error));
+        return throwError(() => error);
       }),
     );
   }

--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -33,12 +33,12 @@ export class AsyncResponse {
   id: string;
 }
 
-export enum ContractStandardEnum {
+export enum ContractSchema {
   ERC20WithData = 'ERC20WithData',
   ERC721WithData = 'ERC721WithData',
 }
 
-export enum ContractMethodEnum {
+export enum ContractMethod {
   ERC20WithDataMintWithData = 'mintWithData',
   ERC20WithDataTransferWithData = 'transferWithData',
   ERC20WithDataBurnWithData = 'burnWithData',
@@ -46,7 +46,8 @@ export enum ContractMethodEnum {
 
 export enum EncodedPoolIdEnum {
   Address = 'address',
-  Standard = 'standard',
+  Standard = 'standard', // deprecated in favor of "schema" below
+  Schema = 'schema',
   Type = 'type',
 }
 
@@ -62,8 +63,14 @@ export enum TokenType {
 }
 
 export interface ITokenPool {
+  address: string | null;
+  schema: string | null;
+  type: TokenType | null;
+}
+
+export interface IValidTokenPool {
   address: string;
-  standard: string;
+  schema: string;
   type: TokenType;
 }
 
@@ -223,6 +230,9 @@ export class TokenPoolEventInfo {
 
   @ApiProperty()
   address: string;
+
+  @ApiProperty()
+  schema: string;
 }
 
 export class TokenPoolEvent extends tokenEventBase {

--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -73,6 +73,12 @@ const requestIdDescription =
   'Optional ID to identify this request. Must be unique for every request. ' +
   'If none is provided, one will be assigned and returned in the 202 response.';
 
+export class TokenPoolConfig {
+  @ApiProperty()
+  @IsDefined()
+  address: string;
+}
+
 export class TokenPool {
   @ApiProperty()
   @IsNotEmpty()
@@ -92,9 +98,7 @@ export class TokenPool {
 
   @ApiProperty({ description: contractConfigDescription })
   @IsDefined()
-  config: {
-    address: string;
-  };
+  config: TokenPoolConfig;
 
   @ApiProperty()
   @IsOptional()

--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -96,8 +96,8 @@ export class TokenPool {
   signer: string;
 
   @ApiProperty()
-  @IsNotEmpty()
-  symbol: string;
+  @IsOptional()
+  symbol?: string;
 
   @ApiProperty({ enum: TokenType })
   @IsEnum(TokenType)

--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -213,9 +213,23 @@ class tokenEventBase {
   signature?: string;
 }
 
+export class TokenPoolEventInfo {
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  address: string;
+}
+
 export class TokenPoolEvent extends tokenEventBase {
   @ApiProperty()
   standard: string;
+
+  @ApiProperty()
+  symbol: string;
+
+  @ApiProperty()
+  info: TokenPoolEventInfo;
 }
 
 export class TokenTransferEvent extends tokenEventBase {

--- a/src/tokens/tokens.service.spec.ts
+++ b/src/tokens/tokens.service.spec.ts
@@ -175,6 +175,11 @@ describe('TokensService', () => {
           standard: ERC20_STANDARD,
           timestamp: expect.any(String),
           type: 'fungible',
+          symbol: SYMBOL,
+          info: {
+            name: NAME,
+            address: CONTRACT_ADDRESS,
+          },
         } as TokenPoolEvent);
       });
     });
@@ -239,6 +244,11 @@ describe('TokensService', () => {
           standard: ERC721_STANDARD,
           timestamp: expect.any(String),
           type: 'nonfungible',
+          symbol: SYMBOL,
+          info: {
+            name: NAME,
+            address: CONTRACT_ADDRESS,
+          },
         } as TokenPoolEvent);
       });
     });
@@ -308,7 +318,24 @@ describe('TokensService', () => {
         standard: ERC20_STANDARD,
         timestamp: expect.any(String),
         type: TokenType.FUNGIBLE,
+        symbol: SYMBOL,
+        info: {
+          name: NAME,
+          address: CONTRACT_ADDRESS,
+        },
       };
+
+      http.post
+        .mockReturnValueOnce(
+          new FakeObservable(<EthConnectReturn>{
+            output: NAME,
+          }),
+        )
+        .mockReturnValueOnce(
+          new FakeObservable(<EthConnectReturn>{
+            output: SYMBOL,
+          }),
+        );
 
       eventstream.createOrUpdateStream = jest.fn(() => mockEventStream);
       eventstream.getOrCreateSubscription = jest.fn(() => new FakeObservable(undefined));
@@ -351,7 +378,24 @@ describe('TokensService', () => {
         standard: ERC721_STANDARD,
         timestamp: expect.any(String),
         type: TokenType.NONFUNGIBLE,
+        symbol: SYMBOL,
+        info: {
+          name: NAME,
+          address: CONTRACT_ADDRESS,
+        },
       };
+
+      http.post
+        .mockReturnValueOnce(
+          new FakeObservable(<EthConnectReturn>{
+            output: NAME,
+          }),
+        )
+        .mockReturnValueOnce(
+          new FakeObservable(<EthConnectReturn>{
+            output: SYMBOL,
+          }),
+        );
 
       eventstream.createOrUpdateStream = jest.fn(() => mockEventStream);
       eventstream.getOrCreateSubscription = jest.fn(() => new FakeObservable(undefined));

--- a/src/tokens/tokens.service.spec.ts
+++ b/src/tokens/tokens.service.spec.ts
@@ -60,10 +60,10 @@ const REQUEST = 'request123';
 const TX = 'tx123';
 const NAME = 'abcTest';
 const SYMBOL = 'abc';
-const ERC20_STANDARD = 'ERC20WithData';
-const ERC20_POOL_ID = `address=${CONTRACT_ADDRESS}&standard=${ERC20_STANDARD}&type=${TokenType.FUNGIBLE}`;
-const ERC721_STANDARD = 'ERC721WithData';
-const ERC721_POOL_ID = `address=${CONTRACT_ADDRESS}&standard=${ERC721_STANDARD}&type=${TokenType.NONFUNGIBLE}`;
+const ERC20_SCHEMA = 'ERC20WithData';
+const ERC20_POOL_ID = `address=${CONTRACT_ADDRESS}&schema=${ERC20_SCHEMA}&type=${TokenType.FUNGIBLE}`;
+const ERC721_SCHEMA = 'ERC721WithData';
+const ERC721_POOL_ID = `address=${CONTRACT_ADDRESS}&schema=${ERC721_SCHEMA}&type=${TokenType.NONFUNGIBLE}`;
 
 const MINT_WITH_DATA = 'mintWithData';
 const TRANSFER_WITH_DATA = 'transferWithData';
@@ -72,7 +72,7 @@ const TRANSFER = 'Transfer';
 const QUERY_NAME = 'name';
 const QUERY_SYMBOL = 'symbol';
 
-const standardAbiMap = {
+const abiMethodMap = {
   ERC20WithData: ERC20WithDataABI.abi as IAbiMethod[],
   ERC721WithData: ERC721WithDataABI.abi as IAbiMethod[],
 };
@@ -172,13 +172,14 @@ describe('TokensService', () => {
         expect(resp).toEqual({
           data: `{"tx":${TX}}`,
           poolId: ERC20_POOL_ID,
-          standard: ERC20_STANDARD,
+          standard: 'ERC20',
           timestamp: expect.any(String),
           type: 'fungible',
           symbol: SYMBOL,
           info: {
             name: NAME,
             address: CONTRACT_ADDRESS,
+            schema: ERC20_SCHEMA,
           },
         } as TokenPoolEvent);
       });
@@ -241,13 +242,14 @@ describe('TokensService', () => {
         expect(resp).toEqual({
           data: `{"tx":${TX}}`,
           poolId: ERC721_POOL_ID,
-          standard: ERC721_STANDARD,
+          standard: 'ERC721',
           timestamp: expect.any(String),
           type: 'nonfungible',
           symbol: SYMBOL,
           info: {
             name: NAME,
             address: CONTRACT_ADDRESS,
+            schema: ERC721_SCHEMA,
           },
         } as TokenPoolEvent);
       });
@@ -315,13 +317,14 @@ describe('TokensService', () => {
 
       const response: TokenPoolEvent = {
         poolId: ERC20_POOL_ID,
-        standard: ERC20_STANDARD,
+        standard: 'ERC20',
         timestamp: expect.any(String),
         type: TokenType.FUNGIBLE,
         symbol: SYMBOL,
         info: {
           name: NAME,
           address: CONTRACT_ADDRESS,
+          schema: ERC20_SCHEMA,
         },
       };
 
@@ -342,12 +345,12 @@ describe('TokensService', () => {
       await expect(service.activatePool(request)).resolves.toEqual(response);
       expect(eventstream.getOrCreateSubscription).toHaveBeenCalledWith(
         BASE_URL,
-        standardAbiMap.ERC20WithData.find(abi => abi.name === TRANSFER) as IAbiMethod,
+        abiMethodMap.ERC20WithData.find(abi => abi.name === TRANSFER) as IAbiMethod,
         'es-4297d77c-0c33-49dc-4e5b-617e0b68fbab',
         'Transfer',
         `${TOPIC}:${ERC20_POOL_ID}:${TRANSFER}`,
         CONTRACT_ADDRESS,
-        standardAbiMap.ERC20WithData.filter(
+        abiMethodMap.ERC20WithData.filter(
           abi =>
             abi.name !== undefined &&
             [
@@ -375,13 +378,14 @@ describe('TokensService', () => {
 
       const response: TokenPoolEvent = {
         poolId: ERC721_POOL_ID,
-        standard: ERC721_STANDARD,
+        standard: 'ERC721',
         timestamp: expect.any(String),
         type: TokenType.NONFUNGIBLE,
         symbol: SYMBOL,
         info: {
           name: NAME,
           address: CONTRACT_ADDRESS,
+          schema: ERC721_SCHEMA,
         },
       };
 
@@ -402,12 +406,12 @@ describe('TokensService', () => {
       await expect(service.activatePool(request)).resolves.toEqual(response);
       expect(eventstream.getOrCreateSubscription).toHaveBeenCalledWith(
         BASE_URL,
-        standardAbiMap.ERC721WithData.find(abi => abi.name === TRANSFER) as IAbiMethod,
+        abiMethodMap.ERC721WithData.find(abi => abi.name === TRANSFER) as IAbiMethod,
         'es-4297d77c-0c33-49dc-4e5b-617e0b68fbab',
         'Transfer',
         `${TOPIC}:${ERC721_POOL_ID}:${TRANSFER}`,
         CONTRACT_ADDRESS,
-        standardAbiMap.ERC721WithData.filter(
+        abiMethodMap.ERC721WithData.filter(
           abi =>
             abi.name !== undefined &&
             [
@@ -439,7 +443,7 @@ describe('TokensService', () => {
         },
         from: IDENTITY,
         to: CONTRACT_ADDRESS,
-        method: standardAbiMap.ERC20WithData.find(abi => abi.name === MINT_WITH_DATA) as IAbiMethod,
+        method: abiMethodMap.ERC20WithData.find(abi => abi.name === MINT_WITH_DATA) as IAbiMethod,
         params: ['0x123', '20', '0x00'],
       };
 
@@ -482,9 +486,7 @@ describe('TokensService', () => {
         },
         from: IDENTITY,
         to: CONTRACT_ADDRESS,
-        method: standardAbiMap.ERC721WithData.find(
-          abi => abi.name === MINT_WITH_DATA,
-        ) as IAbiMethod,
+        method: abiMethodMap.ERC721WithData.find(abi => abi.name === MINT_WITH_DATA) as IAbiMethod,
         params: ['0x123', '721', '0x00'],
       };
 
@@ -515,7 +517,7 @@ describe('TokensService', () => {
         },
         from: IDENTITY,
         to: CONTRACT_ADDRESS,
-        method: standardAbiMap.ERC20WithData.find(
+        method: abiMethodMap.ERC20WithData.find(
           abi => abi.name === TRANSFER_WITH_DATA,
         ) as IAbiMethod,
         params: [IDENTITY, '0x123', '20', '0x00'],
@@ -548,7 +550,7 @@ describe('TokensService', () => {
         },
         from: IDENTITY,
         to: CONTRACT_ADDRESS,
-        method: standardAbiMap.ERC721WithData.find(
+        method: abiMethodMap.ERC721WithData.find(
           abi => abi.name === TRANSFER_WITH_DATA,
         ) as IAbiMethod,
         params: [IDENTITY, '0x123', '721', '0x00'],
@@ -580,7 +582,7 @@ describe('TokensService', () => {
         },
         from: IDENTITY,
         to: CONTRACT_ADDRESS,
-        method: standardAbiMap.ERC20WithData.find(abi => abi.name === BURN_WITH_DATA) as IAbiMethod,
+        method: abiMethodMap.ERC20WithData.find(abi => abi.name === BURN_WITH_DATA) as IAbiMethod,
         params: [IDENTITY, '20', '0x00'],
       };
 
@@ -610,9 +612,7 @@ describe('TokensService', () => {
         },
         from: IDENTITY,
         to: CONTRACT_ADDRESS,
-        method: standardAbiMap.ERC721WithData.find(
-          abi => abi.name === BURN_WITH_DATA,
-        ) as IAbiMethod,
+        method: abiMethodMap.ERC721WithData.find(abi => abi.name === BURN_WITH_DATA) as IAbiMethod,
         params: [IDENTITY, '721', '0x00'],
       };
 

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -237,7 +237,7 @@ export class TokensService {
     const encodedPoolId = packPoolId(poolId);
 
     const nameAndSymbol = await this.queryPool(poolId);
-    if (nameAndSymbol.symbol !== dto.symbol) {
+    if (dto.symbol !== undefined && dto.symbol !== '' && dto.symbol !== nameAndSymbol.symbol) {
       throw new BadRequestException(
         `Supplied symbol '${dto.symbol}' does not match expected '${nameAndSymbol.symbol}'`,
       );

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -245,11 +245,7 @@ export class TokensService {
     });
 
     const nameAndSymbol = await this.queryPool(encodedPoolId);
-    if (nameAndSymbol.name !== dto.name) {
-      throw new BadRequestException(
-        `Supplied name '${dto.name}' does not match expected '${nameAndSymbol.name}'`,
-      );
-    } else if (nameAndSymbol.symbol !== dto.symbol) {
+    if (nameAndSymbol.symbol !== dto.symbol) {
       throw new BadRequestException(
         `Supplied symbol '${dto.symbol}' does not match expected '${nameAndSymbol.symbol}'`,
       );
@@ -261,6 +257,11 @@ export class TokensService {
       standard: encodedPoolId.get(EncodedPoolIdEnum.Standard)?.toString() ?? '',
       timestamp: Date.now().toString(),
       type: dto.type,
+      symbol: nameAndSymbol.symbol,
+      info: {
+        name: nameAndSymbol.name,
+        address: dto.config.address,
+      },
     };
 
     return tokenPoolEvent;
@@ -293,11 +294,18 @@ export class TokensService {
       dto.transaction?.blockNumber ?? '0',
     );
 
+    const nameAndSymbol = await this.queryPool(encodedPoolId);
+
     const tokenPoolEvent: TokenPoolEvent = {
       poolId: dto.poolId,
       standard: validPoolId.standard,
       timestamp: Date.now().toString(),
       type: validPoolId.type,
+      symbol: nameAndSymbol.symbol,
+      info: {
+        name: nameAndSymbol.name,
+        address: validPoolId.address,
+      },
     };
 
     return tokenPoolEvent;

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -159,6 +159,13 @@ export class TokensService {
     return;
   }
 
+  private async getStream() {
+    if (this.stream === undefined) {
+      this.stream = await this.eventstream.createOrUpdateStream(this.topic);
+    }
+    return this.stream;
+  }
+
   private postOptions(signer: string, requestId?: string) {
     const from = `${this.shortPrefix}-from`;
     const sync = `${this.shortPrefix}-sync`;
@@ -196,9 +203,7 @@ export class TokensService {
 
   async activatePool(dto: TokenPoolActivate) {
     const validPoolId: ITokenPool = this.validatePoolId(new URLSearchParams(dto.poolId));
-    if (this.stream === undefined) {
-      this.stream = await this.eventstream.createOrUpdateStream(this.topic);
-    }
+    const stream = await this.getStream();
     const encodedPoolId = new URLSearchParams(dto.poolId);
     const methodAbi = this.getMethodAbi(encodedPoolId, 'TRANSFEREVENT');
 
@@ -215,7 +220,7 @@ export class TokensService {
     await this.eventstream.getOrCreateSubscription(
       `${this.baseUrl}`,
       methodAbi,
-      this.stream.id,
+      stream.id,
       transferEvent,
       packSubscriptionName(this.topic, dto.poolId, transferEvent),
       validPoolId.address,

--- a/src/tokens/tokens.util.spec.ts
+++ b/src/tokens/tokens.util.spec.ts
@@ -14,7 +14,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { decodeHex, encodeHex, packSubscriptionName, unpackSubscriptionName } from './tokens.util';
+import { ITokenPool, TokenType } from './tokens.interfaces';
+import {
+  decodeHex,
+  encodeHex,
+  packPoolId,
+  packSubscriptionName,
+  unpackPoolId,
+  unpackSubscriptionName,
+} from './tokens.util';
 
 describe('Util', () => {
   it('encodeHex', () => {
@@ -59,6 +67,30 @@ describe('Util', () => {
       prefix: 'tok:en',
       poolId: '0x123456',
       event: 'create',
+    });
+  });
+
+  it('packPoolId', () => {
+    expect(
+      packPoolId({
+        address: '0x12345',
+        schema: 'ERC20WithData',
+        type: TokenType.FUNGIBLE,
+      }),
+    ).toEqual('address=0x12345&schema=ERC20WithData&type=fungible');
+  });
+
+  it('unpackPoolId', () => {
+    expect(unpackPoolId('address=0x12345&schema=ERC20WithData&type=fungible')).toEqual(<ITokenPool>{
+      address: '0x12345',
+      schema: 'ERC20WithData',
+      type: TokenType.FUNGIBLE,
+    });
+
+    expect(unpackPoolId('address=0x12345&standard=ERC20WithData&type=fungible')).toEqual(<ITokenPool>{
+      address: '0x12345',
+      schema: 'ERC20WithData',
+      type: TokenType.FUNGIBLE,
     });
   });
 });

--- a/src/tokens/tokens.util.ts
+++ b/src/tokens/tokens.util.ts
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { EncodedPoolIdEnum, ITokenPool, IValidTokenPool, TokenType } from './tokens.interfaces';
+
 /**
  * Encode a UTF-8 string into hex bytes with a leading 0x
  */
@@ -48,5 +50,24 @@ export function unpackSubscriptionName(prefix: string, data: string) {
     prefix,
     poolId: parts?.[0],
     event: parts?.[1],
+  };
+}
+
+export function packPoolId(poolId: IValidTokenPool) {
+  const encodedPoolId = new URLSearchParams({
+    [EncodedPoolIdEnum.Address]: poolId.address,
+    [EncodedPoolIdEnum.Schema]: poolId.schema,
+    [EncodedPoolIdEnum.Type]: poolId.type,
+  });
+  return encodedPoolId.toString();
+}
+
+export function unpackPoolId(data: string): ITokenPool {
+  const encodedPoolId = new URLSearchParams(data);
+  return {
+    address: encodedPoolId.get(EncodedPoolIdEnum.Address),
+    schema:
+      encodedPoolId.get(EncodedPoolIdEnum.Schema) ?? encodedPoolId.get(EncodedPoolIdEnum.Standard),
+    type: encodedPoolId.get(EncodedPoolIdEnum.Type) as TokenType,
   };
 }

--- a/test/erc20.e2e-spec.ts
+++ b/test/erc20.e2e-spec.ts
@@ -57,16 +57,16 @@ const REQUEST = 'request123';
 const TX = 'tx123';
 const NAME = 'abcTest';
 const SYMBOL = 'abc';
-const ERC20_STANDARD = 'ERC20WithData';
-const ERC20_POOL_ID = `address=${CONTRACT_ADDRESS}&standard=${ERC20_STANDARD}&type=${TokenType.FUNGIBLE}`;
-const ERC721_STANDARD = 'ERC721WithData';
-const ERC721_POOL_ID = `address=${CONTRACT_ADDRESS}&standard=${ERC721_STANDARD}&type=${TokenType.NONFUNGIBLE}`;
+const ERC20_SCHEMA = 'ERC20WithData';
+const ERC20_POOL_ID = `address=${CONTRACT_ADDRESS}&schema=${ERC20_SCHEMA}&type=${TokenType.FUNGIBLE}`;
+const ERC721_SCHEMA = 'ERC721WithData';
+const ERC721_POOL_ID = `address=${CONTRACT_ADDRESS}&schema=${ERC721_SCHEMA}&type=${TokenType.NONFUNGIBLE}`;
 
 const MINT_WITH_DATA = 'mintWithData';
 const TRANSFER_WITH_DATA = 'transferWithData';
 const BURN_WITH_DATA = 'burnWithData';
 
-const standardAbiMap = {
+const abiMethodMap = {
   ERC20WithData: ERC20WithDataABI.abi as IAbiMethod[],
   ERC721WithData: ERC721WithDataABI.abi as IAbiMethod[],
 };
@@ -147,8 +147,8 @@ describe('AppController - ERC20/ERC721 (e2e)', () => {
 
     const expectedResponse: TokenPoolEvent = expect.objectContaining({
       data: `{"tx":${TX}}`,
-      poolId: `address=${CONTRACT_ADDRESS}&standard=${ERC20_STANDARD}&type=${TokenType.FUNGIBLE}`,
-      standard: ERC20_STANDARD,
+      poolId: `address=${CONTRACT_ADDRESS}&schema=${ERC20_SCHEMA}&type=${TokenType.FUNGIBLE}`,
+      standard: 'ERC20',
       timestamp: expect.any(String),
       type: TokenType.FUNGIBLE,
     });
@@ -182,8 +182,8 @@ describe('AppController - ERC20/ERC721 (e2e)', () => {
 
     const expectedResponse: TokenPoolEvent = expect.objectContaining({
       data: `{"tx":${TX}}`,
-      poolId: `address=${CONTRACT_ADDRESS}&standard=${ERC20_STANDARD}&type=${TokenType.FUNGIBLE}`,
-      standard: ERC20_STANDARD,
+      poolId: `address=${CONTRACT_ADDRESS}&schema=${ERC20_SCHEMA}&type=${TokenType.FUNGIBLE}`,
+      standard: 'ERC20',
       timestamp: expect.any(String),
       type: TokenType.FUNGIBLE,
     });
@@ -217,8 +217,8 @@ describe('AppController - ERC20/ERC721 (e2e)', () => {
 
     const expectedResponse: TokenPoolEvent = expect.objectContaining({
       data: `{"tx":${TX}}`,
-      poolId: `address=${CONTRACT_ADDRESS}&standard=${ERC721_STANDARD}&type=${TokenType.NONFUNGIBLE}`,
-      standard: ERC721_STANDARD,
+      poolId: `address=${CONTRACT_ADDRESS}&schema=${ERC721_SCHEMA}&type=${TokenType.NONFUNGIBLE}`,
+      standard: 'ERC721',
       timestamp: expect.any(String),
       type: TokenType.NONFUNGIBLE,
     });
@@ -274,7 +274,7 @@ describe('AppController - ERC20/ERC721 (e2e)', () => {
       },
       from: IDENTITY,
       to: CONTRACT_ADDRESS,
-      method: standardAbiMap.ERC20WithData.find(abi => abi.name === MINT_WITH_DATA) as IAbiMethod,
+      method: abiMethodMap.ERC20WithData.find(abi => abi.name === MINT_WITH_DATA) as IAbiMethod,
       params: ['0x123', '20', '0x00'],
     };
 
@@ -305,7 +305,7 @@ describe('AppController - ERC20/ERC721 (e2e)', () => {
       },
       from: IDENTITY,
       to: CONTRACT_ADDRESS,
-      method: standardAbiMap.ERC721WithData.find(abi => abi.name === MINT_WITH_DATA) as IAbiMethod,
+      method: abiMethodMap.ERC721WithData.find(abi => abi.name === MINT_WITH_DATA) as IAbiMethod,
       params: ['0x123', '721', '0x00'],
     };
 
@@ -337,9 +337,7 @@ describe('AppController - ERC20/ERC721 (e2e)', () => {
       },
       from: IDENTITY,
       to: CONTRACT_ADDRESS,
-      method: standardAbiMap.ERC20WithData.find(
-        abi => abi.name === TRANSFER_WITH_DATA,
-      ) as IAbiMethod,
+      method: abiMethodMap.ERC20WithData.find(abi => abi.name === TRANSFER_WITH_DATA) as IAbiMethod,
       params: [IDENTITY, '0x123', '20', '0x00'],
     };
 
@@ -371,7 +369,7 @@ describe('AppController - ERC20/ERC721 (e2e)', () => {
       },
       from: IDENTITY,
       to: CONTRACT_ADDRESS,
-      method: standardAbiMap.ERC721WithData.find(
+      method: abiMethodMap.ERC721WithData.find(
         abi => abi.name === TRANSFER_WITH_DATA,
       ) as IAbiMethod,
       params: [IDENTITY, '0x123', '721', '0x00'],
@@ -404,7 +402,7 @@ describe('AppController - ERC20/ERC721 (e2e)', () => {
       },
       from: IDENTITY,
       to: CONTRACT_ADDRESS,
-      method: standardAbiMap.ERC20WithData.find(abi => abi.name === BURN_WITH_DATA) as IAbiMethod,
+      method: abiMethodMap.ERC20WithData.find(abi => abi.name === BURN_WITH_DATA) as IAbiMethod,
       params: [IDENTITY, '20', '0x00'],
     };
 
@@ -435,7 +433,7 @@ describe('AppController - ERC20/ERC721 (e2e)', () => {
       },
       from: IDENTITY,
       to: CONTRACT_ADDRESS,
-      method: standardAbiMap.ERC721WithData.find(abi => abi.name === BURN_WITH_DATA) as IAbiMethod,
+      method: abiMethodMap.ERC721WithData.find(abi => abi.name === BURN_WITH_DATA) as IAbiMethod,
       params: [IDENTITY, '721', '0x00'],
     };
 

--- a/test/erc20.e2e-spec.ts
+++ b/test/erc20.e2e-spec.ts
@@ -29,6 +29,7 @@ import { EventStreamProxyGateway } from '../src/eventstream-proxy/eventstream-pr
 import {
   EthConnectAsyncResponse,
   EthConnectMsgRequest,
+  EthConnectReturn,
   IAbiMethod,
   TokenBurn,
   TokenMint,
@@ -153,6 +154,16 @@ describe('AppController - ERC20/ERC721 (e2e)', () => {
     });
 
     http.get = jest.fn(() => new FakeObservable(expectedResponse));
+    http.post.mockImplementation((uri, options) => {
+      switch (options.method.name) {
+        case 'name':
+          return new FakeObservable(<EthConnectReturn>{ output: NAME });
+        case 'symbol':
+          return new FakeObservable(<EthConnectReturn>{ output: SYMBOL });
+        default:
+          throw new Error('Unknown "post" call: ' + JSON.stringify(options));
+      }
+    });
 
     const response = await server.post('/createpool').send(request).expect(200);
     expect(response.body).toEqual(expectedResponse);
@@ -178,6 +189,16 @@ describe('AppController - ERC20/ERC721 (e2e)', () => {
     });
 
     http.get = jest.fn(() => new FakeObservable(expectedResponse));
+    http.post.mockImplementation((uri, options) => {
+      switch (options.method.name) {
+        case 'name':
+          return new FakeObservable(<EthConnectReturn>{ output: NAME });
+        case 'symbol':
+          return new FakeObservable(<EthConnectReturn>{ output: SYMBOL });
+        default:
+          throw new Error('Unknown "post" call: ' + JSON.stringify(options));
+      }
+    });
 
     const response = await server.post('/createpool').send(request).expect(200);
     expect(response.body).toEqual(expectedResponse);
@@ -203,6 +224,16 @@ describe('AppController - ERC20/ERC721 (e2e)', () => {
     });
 
     http.get = jest.fn(() => new FakeObservable(expectedResponse));
+    http.post.mockImplementation((uri, options) => {
+      switch (options.method.name) {
+        case 'name':
+          return new FakeObservable(<EthConnectReturn>{ output: NAME });
+        case 'symbol':
+          return new FakeObservable(<EthConnectReturn>{ output: SYMBOL });
+        default:
+          throw new Error('Unknown "post" call: ' + JSON.stringify(options));
+      }
+    });
 
     const response = await server.post('/createpool').send(request).expect(200);
     expect(response.body).toEqual(expectedResponse);

--- a/test/ws.e2e-spec.ts
+++ b/test/ws.e2e-spec.ts
@@ -48,9 +48,9 @@ const IDENTITY = '0x321';
 const PREFIX = 'fly';
 const TOPIC = 'tokentest';
 const ERC20_STANDARD = 'ERC20WithData';
-const ERC20_POOL_ID = `address=${CONTRACT_ADDRESS}&standard=${ERC20_STANDARD}&type=${TokenType.FUNGIBLE}`;
+const ERC20_POOL_ID = `address=${CONTRACT_ADDRESS}&schema=${ERC20_STANDARD}&type=${TokenType.FUNGIBLE}`;
 const ERC721_STANDARD = 'ERC721WithData';
-const ERC721_POOL_ID = `address=${CONTRACT_ADDRESS}&standard=${ERC721_STANDARD}&type=${TokenType.NONFUNGIBLE}`;
+const ERC721_POOL_ID = `address=${CONTRACT_ADDRESS}&schema=${ERC721_STANDARD}&type=${TokenType.NONFUNGIBLE}`;
 const ERC721_BASE_URI = 'firefly://token/';
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
@@ -213,6 +213,54 @@ describe('WebSocket AppController (e2e)', () => {
         location: 'address=bob',
         signature: transferEventSignature,
         poolId: ERC20_POOL_ID,
+        to: 'A',
+        amount: '5',
+        signer: IDENTITY,
+        data: 'test',
+        timestamp: '2020-01-01 00:00:00Z',
+        rawOutput: {
+          from: ZERO_ADDRESS,
+          to: 'A',
+          value: '5',
+        },
+        transaction: {
+          address: 'bob',
+          blockNumber: '1',
+          transactionIndex: '0x0',
+          transactionHash: '0x123',
+          logIndex: '1',
+          signature: transferEventSignature,
+        },
+        type: 'fungible',
+      } as TokenMintEvent,
+    };
+
+    await server
+      .ws('/api/ws')
+      .exec(() => {
+        expect(eventHandler).toBeDefined();
+        eventHandler([mockERC20MintTransferEvent]);
+      })
+      .expectJson(message => {
+        expect(message.id).toBeDefined();
+        delete message.id;
+        expect(message).toEqual(mockMintWebSocketMessage);
+        return true;
+      });
+  });
+
+  it('Websocket: ERC20 token mint event with old poolId', async () => {
+    eventstream.getSubscription.mockReturnValueOnce(<EventStreamSubscription>{
+      name: TOPIC + ':' + `address=${CONTRACT_ADDRESS}&standard=${ERC20_STANDARD}&type=${TokenType.FUNGIBLE}`,
+    });
+
+    const mockMintWebSocketMessage: WebSocketMessage = {
+      event: 'token-mint',
+      data: {
+        id: '000000000001/000000/000001',
+        location: 'address=bob',
+        signature: transferEventSignature,
+        poolId: `address=${CONTRACT_ADDRESS}&standard=${ERC20_STANDARD}&type=${TokenType.FUNGIBLE}`,
         to: 'A',
         amount: '5',
         signer: IDENTITY,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "solidity"]
 }


### PR DESCRIPTION
This is the easiest solution to https://github.com/hyperledger/firefly/issues/557.

When creating an ERC20 or ERC721 pool by pointing at an existing contract address, it requires that you pass a pool name and symbol to FireFly which exactly match the name and symbol embedded in the pre-deployed contract.