### PR TITLE
Allow activation to register from a custom block number

### DIFF
--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -114,6 +114,10 @@ export class TokenPoolConfig {
 
   @ApiProperty()
   @IsOptional()
+  blockNumber?: number;
+
+  @ApiProperty()
+  @IsOptional()
   withData?: boolean;
 }
 
@@ -217,6 +221,10 @@ export class TokenPoolActivate {
   @ApiProperty()
   @IsNotEmpty()
   poolId: string;
+
+  @ApiProperty()
+  @IsOptional()
+  poolConfig?: TokenPoolConfig;
 
   @ApiProperty()
   @IsOptional()

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -37,6 +37,7 @@ import {
   ApprovalEvent,
   ApprovalForAllEvent,
   AsyncResponse,
+  BlockchainTransaction,
   ContractSchema,
   EthConnectAsyncResponse,
   EthConnectMsgRequest,
@@ -45,6 +46,7 @@ import {
   ITokenPool,
   IValidTokenPool,
   TokenApproval,
+  TokenApprovalConfig,
   TokenApprovalEvent,
   TokenBurn,
   TokenBurnEvent,
@@ -52,6 +54,7 @@ import {
   TokenMintEvent,
   TokenPool,
   TokenPoolActivate,
+  TokenPoolConfig,
   TokenPoolEvent,
   TokenTransfer,
   TokenTransferEvent,
@@ -415,6 +418,16 @@ export class TokensService {
     return tokenPoolEvent;
   }
 
+  getSubscriptionBlockNumber(poolConfig?: TokenPoolConfig, transaction?: BlockchainTransaction): string {
+    let blockNumber = '0';
+    if (poolConfig?.blockNumber) {
+      blockNumber = String(poolConfig.blockNumber)
+    } else if (transaction?.blockNumber) {
+      blockNumber = transaction.blockNumber;
+    }
+    return blockNumber;
+  }
+
   async activatePool(dto: TokenPoolActivate) {
     const poolId = unpackPoolId(dto.poolId);
     if (!this.validatePoolId(poolId)) {
@@ -453,7 +466,7 @@ export class TokensService {
         packSubscriptionName(this.topic, dto.poolId, abiEvents.TRANSFER),
         poolId.address,
         methodsToSubTo,
-        dto.transaction?.blockNumber ?? '0',
+        this.getSubscriptionBlockNumber(dto.poolConfig, dto.transaction),
       ),
       this.eventstream.getOrCreateSubscription(
         `${this.baseUrl}`,
@@ -463,7 +476,7 @@ export class TokensService {
         packSubscriptionName(this.topic, dto.poolId, abiEvents.APPROVAL),
         poolId.address,
         methodsToSubTo,
-        dto.transaction?.blockNumber ?? '0',
+        this.getSubscriptionBlockNumber(dto.poolConfig, dto.transaction),
       ),
     ];
     if (abiEvents.APPROVALFORALL !== null) {
@@ -480,7 +493,7 @@ export class TokensService {
           packSubscriptionName(this.topic, dto.poolId, abiEvents.APPROVALFORALL),
           poolId.address,
           methodsToSubTo,
-          dto.transaction?.blockNumber ?? '0',
+          this.getSubscriptionBlockNumber(dto.poolConfig, dto.transaction),
         ),
       );
     }


### PR DESCRIPTION
- Allow `blockNumber` to be optionally included in the ERC-20/ERC-721 custom `config` section
- Allow `poolConfig` to be passed by FireFly during `activate`
    - This will require (non-breaking) changes on the FireFly core API contract too
- Create the EthConnect subscriptions from the specified `blockNumber` in preference above all other block numbers