### PR TITLE
Clarify token fields around "id", "locator", and "subject"

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Successful POST operations will also result in a detailed event corresponding to
 transaction that was performed. The events and corresponding data items are:
 
 * `token-pool` - Token pool created (outputs: poolLocator, signer, data)
-* `token-mint` - Tokens minted (outputs: subject, poolLocator, tokenIndex, signer, to, amount, data)
-* `token-burn` - Tokens burned (outputs: subject, poolLocator, tokenIndex, signer, from, amount, data)
-* `token-transfer` - Tokens transferred (outputs: subject, poolLocator, signer, from, to, amount, data)
-* `token-approval` - Tokens approved (outputs: subject, poolLocator, signer, operator, approved, data)
+* `token-mint` - Tokens minted (outputs: id, poolLocator, tokenIndex, signer, to, amount, data)
+* `token-burn` - Tokens burned (outputs: id, poolLocator, tokenIndex, signer, from, amount, data)
+* `token-transfer` - Tokens transferred (outputs: id, poolLocator, signer, from, to, amount, data)
+* `token-approval` - Tokens approved (outputs: id, subject, poolLocator, signer, operator, approved, data)
 
 If multiple websocket clients are connected, only one will receive these events.
 Each one of these _must_ be acknowledged by replying on the websocket with `{event: "ack", data: {id}}`.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ calls, and maps ethconnect events to outgoing websocket events.
 
 ## POST APIs
 
-The following POST APIs are exposed under `/api/v1`. Note that the term `poolId` is the term we use for the address of contract instance:
+The following POST APIs are exposed under `/api/v1`:
 
 * `POST /createpool` - Create a new instance of an ERC20 contract (inputs: name, symbol, data)
-* `POST /activatepool` - Activate a token contract to begin receiving transfers (inputs: poolId)
-* `POST /mint` - Mint new tokens (inputs: poolId, to, amount, data)
-* `POST /burn` - Burn tokens (inputs: poolId, tokenIndex, from, amount, data)
-* `POST /transfer` - Transfer tokens (inputs: poolId, tokenIndex, from, to, amount, data)
+* `POST /activatepool` - Activate a token contract to begin receiving transfers (inputs: poolLocator)
+* `POST /mint` - Mint new tokens (inputs: poolLocator, to, amount, data)
+* `POST /burn` - Burn tokens (inputs: poolLocator, tokenIndex, from, amount, data)
+* `POST /transfer` - Transfer tokens (inputs: poolLocator, tokenIndex, from, to, amount, data)
 
 All requests may be optionally accompanied by a `requestId`, which must be unique for every
 request and will be returned in the "receipt" websocket event.
@@ -39,10 +39,11 @@ not require any acknowledgment).
 Successful POST operations will also result in a detailed event corresponding to the type of
 transaction that was performed. The events and corresponding data items are:
 
-* `token-pool` - Token pool created (outputs: poolId, signer, data)
-* `token-mint` - Tokens minted (outputs: id, poolId, tokenIndex, signer, to, amount, data)
-* `token-burn` - Tokens burned (outputs: id, poolId, tokenIndex, signer, from, amount, data)
-* `token-transfer` - Tokens transferred (outputs: id, poolId, signer, from, to, amount, data)
+* `token-pool` - Token pool created (outputs: poolLocator, signer, data)
+* `token-mint` - Tokens minted (outputs: subject, poolLocator, tokenIndex, signer, to, amount, data)
+* `token-burn` - Tokens burned (outputs: subject, poolLocator, tokenIndex, signer, from, amount, data)
+* `token-transfer` - Tokens transferred (outputs: subject, poolLocator, signer, from, to, amount, data)
+* `token-approval` - Tokens approved (outputs: subject, poolLocator, signer, operator, approved, data)
 
 If multiple websocket clients are connected, only one will receive these events.
 Each one of these _must_ be acknowledged by replying on the websocket with `{event: "ack", data: {id}}`.
@@ -51,7 +52,6 @@ Each one of these _must_ be acknowledged by replying on the websocket with `{eve
 
 The following GET APIs are exposed under `/api/v1`:
 
-* `GET /balance` - Get token balance (inputs: poolId, tokenIndex, account)
 * `GET /receipt/:id` - Get receipt for a previous request
 
 ## Running the service

--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -335,7 +335,7 @@ export class TokenPoolEvent extends tokenEventBase {
 
 export class TokenTransferEvent extends tokenEventBase {
   @ApiProperty()
-  id: string;
+  subject: string;
 
   @ApiProperty()
   tokenIndex?: string;
@@ -357,6 +357,9 @@ export class TokenMintEvent extends OmitType(TokenTransferEvent, ['from']) {}
 export class TokenBurnEvent extends OmitType(TokenTransferEvent, ['to']) {}
 
 export class TokenApprovalEvent extends tokenEventBase {
+  @ApiProperty()
+  subject: string;
+
   @ApiProperty()
   operator: string;
 

--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -323,7 +323,7 @@ export class TokenPoolEvent extends tokenEventBase {
 
 export class TokenTransferEvent extends tokenEventBase {
   @ApiProperty()
-  subject: string;
+  id: string;
 
   @ApiProperty()
   tokenIndex?: string;
@@ -346,6 +346,9 @@ export class TokenBurnEvent extends OmitType(TokenTransferEvent, ['to']) {}
 
 export class TokenApprovalEvent extends tokenEventBase {
   @ApiProperty()
+  id: string;
+
+  @ApiProperty()
   subject: string;
 
   @ApiProperty()
@@ -354,6 +357,8 @@ export class TokenApprovalEvent extends tokenEventBase {
   @ApiProperty()
   approved: boolean;
 }
+
+// ABI format
 
 export interface IAbiInput {
   indexed?: boolean;

--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -73,17 +73,11 @@ export enum ContractMethod {
   ERC20WithDataBurnWithData = 'burnWithData',
 }
 
-export enum EncodedPoolIdEnum {
+export enum EncodedPoolLocatorEnum {
   Address = 'address',
   Standard = 'standard', // deprecated in favor of "schema" below
   Schema = 'schema',
   Type = 'type',
-}
-
-export interface IPoolId {
-  address: string;
-  standard: string;
-  type: string;
 }
 
 export enum TokenType {
@@ -91,13 +85,13 @@ export enum TokenType {
   NONFUNGIBLE = 'nonfungible',
 }
 
-export interface ITokenPool {
+export interface IPoolLocator {
   address: string | null;
   schema: string | null;
   type: TokenType | null;
 }
 
-export interface IValidTokenPool {
+export interface IValidPoolLocator {
   address: string;
   schema: string;
   type: TokenType;
@@ -164,7 +158,7 @@ export class TokenApprovalConfig {
 export class TokenApproval {
   @ApiProperty()
   @IsNotEmpty()
-  poolId: string;
+  poolLocator: string;
 
   @ApiProperty()
   @IsNotEmpty()
@@ -191,13 +185,11 @@ export class TokenApproval {
   config?: TokenApprovalConfig;
 }
 
-export class BlockLocator {
+export class BlockchainInfo {
   @ApiProperty()
   @IsNotEmpty()
   blockNumber: string;
-}
 
-export class BlockchainInfo extends BlockLocator {
   @ApiProperty()
   transactionIndex: string;
 
@@ -240,15 +232,11 @@ export class BlockchainEvent {
 export class TokenPoolActivate {
   @ApiProperty()
   @IsNotEmpty()
-  poolId: string;
+  poolLocator: string;
 
   @ApiProperty()
   @IsOptional()
   config?: TokenPoolConfig;
-
-  @ApiProperty()
-  @IsOptional()
-  locator?: BlockLocator;
 
   @ApiProperty({ description: requestIdDescription })
   @IsOptional()
@@ -258,7 +246,7 @@ export class TokenPoolActivate {
 export class TokenTransfer {
   @ApiProperty()
   @IsNotEmpty()
-  poolId: string;
+  poolLocator: string;
 
   @ApiProperty()
   @IsOptional()
@@ -296,7 +284,7 @@ export class TokenBurn extends OmitType(TokenTransfer, ['to']) {}
 
 class tokenEventBase {
   @ApiProperty()
-  poolId: string;
+  poolLocator: string;
 
   @ApiProperty()
   signer?: string;

--- a/src/tokens/tokens.service.spec.ts
+++ b/src/tokens/tokens.service.spec.ts
@@ -218,7 +218,7 @@ describe('TokensService', () => {
       await service.createPool(request).then(resp => {
         expect(resp).toEqual({
           data: `{"tx":${TX}}`,
-          poolId: ERC20_NO_DATA_POOL_ID,
+          poolLocator: ERC20_NO_DATA_POOL_ID,
           standard: 'ERC20',
           type: 'fungible',
           symbol: SYMBOL,
@@ -233,7 +233,7 @@ describe('TokensService', () => {
 
     it('should activate ERC20NoData pool correctly and return correct values', async () => {
       const request: TokenPoolActivate = {
-        poolId: ERC20_NO_DATA_POOL_ID,
+        poolLocator: ERC20_NO_DATA_POOL_ID,
       };
 
       const mockEventStream: EventStream = {
@@ -242,7 +242,7 @@ describe('TokensService', () => {
       };
 
       const response: TokenPoolEvent = {
-        poolId: ERC20_NO_DATA_POOL_ID,
+        poolLocator: ERC20_NO_DATA_POOL_ID,
         standard: 'ERC20',
         type: TokenType.FUNGIBLE,
         symbol: SYMBOL,
@@ -280,7 +280,7 @@ describe('TokensService', () => {
       const request: TokenMint = {
         amount: '20',
         signer: IDENTITY,
-        poolId: ERC20_NO_DATA_POOL_ID,
+        poolLocator: ERC20_NO_DATA_POOL_ID,
         to: '0x123',
       };
 
@@ -310,7 +310,7 @@ describe('TokensService', () => {
       const request: TokenTransfer = {
         amount: '20',
         signer: IDENTITY,
-        poolId: ERC20_NO_DATA_POOL_ID,
+        poolLocator: ERC20_NO_DATA_POOL_ID,
         from: IDENTITY,
         to: '0x123',
       };
@@ -343,7 +343,7 @@ describe('TokensService', () => {
       const request: TokenBurn = {
         amount: '20',
         signer: IDENTITY,
-        poolId: ERC20_NO_DATA_POOL_ID,
+        poolLocator: ERC20_NO_DATA_POOL_ID,
         from: IDENTITY,
       };
 
@@ -387,7 +387,7 @@ describe('TokensService', () => {
       await service.createPool(request).then(resp => {
         expect(resp).toEqual({
           data: `{"tx":${TX}}`,
-          poolId: ERC20_WITH_DATA_POOL_ID,
+          poolLocator: ERC20_WITH_DATA_POOL_ID,
           standard: 'ERC20',
           type: 'fungible',
           symbol: SYMBOL,
@@ -416,7 +416,7 @@ describe('TokensService', () => {
       await service.createPool(request).then(resp => {
         expect(resp).toEqual({
           data: `{"tx":${TX}}`,
-          poolId: ERC20_WITH_DATA_POOL_ID,
+          poolLocator: ERC20_WITH_DATA_POOL_ID,
           standard: 'ERC20',
           type: 'fungible',
           symbol: SYMBOL,
@@ -431,7 +431,7 @@ describe('TokensService', () => {
 
     it('should activate ERC20WithData pool correctly and return correct values', async () => {
       const request: TokenPoolActivate = {
-        poolId: ERC20_WITH_DATA_POOL_ID,
+        poolLocator: ERC20_WITH_DATA_POOL_ID,
       };
 
       const mockEventStream: EventStream = {
@@ -440,7 +440,7 @@ describe('TokensService', () => {
       };
 
       const response: TokenPoolEvent = {
-        poolId: ERC20_WITH_DATA_POOL_ID,
+        poolLocator: ERC20_WITH_DATA_POOL_ID,
         standard: 'ERC20',
         type: TokenType.FUNGIBLE,
         symbol: SYMBOL,
@@ -476,7 +476,7 @@ describe('TokensService', () => {
       const request: TokenMint = {
         amount: '20',
         signer: IDENTITY,
-        poolId: ERC20_WITH_DATA_POOL_ID,
+        poolLocator: ERC20_WITH_DATA_POOL_ID,
         to: '0x123',
       };
 
@@ -506,7 +506,7 @@ describe('TokensService', () => {
       const request: TokenTransfer = {
         amount: '20',
         signer: IDENTITY,
-        poolId: ERC20_WITH_DATA_POOL_ID,
+        poolLocator: ERC20_WITH_DATA_POOL_ID,
         from: IDENTITY,
         to: '0x123',
       };
@@ -537,7 +537,7 @@ describe('TokensService', () => {
       const request: TokenBurn = {
         amount: '20',
         signer: IDENTITY,
-        poolId: ERC20_WITH_DATA_POOL_ID,
+        poolLocator: ERC20_WITH_DATA_POOL_ID,
         from: IDENTITY,
       };
 
@@ -581,7 +581,7 @@ describe('TokensService', () => {
       await service.createPool(request).then(resp => {
         expect(resp).toEqual({
           data: `{"tx":${TX}}`,
-          poolId: ERC721_NO_DATA_POOL_ID,
+          poolLocator: ERC721_NO_DATA_POOL_ID,
           standard: 'ERC721',
           type: 'nonfungible',
           symbol: SYMBOL,
@@ -596,7 +596,7 @@ describe('TokensService', () => {
 
     it('should activate ERC721NoData pool correctly and return correct values', async () => {
       const request: TokenPoolActivate = {
-        poolId: ERC721_NO_DATA_POOL_ID,
+        poolLocator: ERC721_NO_DATA_POOL_ID,
       };
 
       const mockEventStream: EventStream = {
@@ -605,7 +605,7 @@ describe('TokensService', () => {
       };
 
       const response: TokenPoolEvent = {
-        poolId: ERC721_NO_DATA_POOL_ID,
+        poolLocator: ERC721_NO_DATA_POOL_ID,
         standard: 'ERC721',
         type: TokenType.NONFUNGIBLE,
         symbol: SYMBOL,
@@ -644,7 +644,7 @@ describe('TokensService', () => {
         amount: '2',
         tokenIndex: '721',
         signer: IDENTITY,
-        poolId: ERC721_NO_DATA_POOL_ID,
+        poolLocator: ERC721_NO_DATA_POOL_ID,
         to: '0x123',
       };
       await expect(service.mint(request)).rejects.toThrowError(
@@ -656,7 +656,7 @@ describe('TokensService', () => {
       const request: TokenMint = {
         tokenIndex: '721',
         signer: IDENTITY,
-        poolId: ERC721_NO_DATA_POOL_ID,
+        poolLocator: ERC721_NO_DATA_POOL_ID,
         to: '0x123',
       };
 
@@ -686,7 +686,7 @@ describe('TokensService', () => {
       const request: TokenTransfer = {
         tokenIndex: '721',
         signer: IDENTITY,
-        poolId: ERC721_NO_DATA_POOL_ID,
+        poolLocator: ERC721_NO_DATA_POOL_ID,
         from: IDENTITY,
         to: '0x123',
       };
@@ -719,7 +719,7 @@ describe('TokensService', () => {
       const request: TokenBurn = {
         tokenIndex: '721',
         signer: IDENTITY,
-        poolId: ERC721_NO_DATA_POOL_ID,
+        poolLocator: ERC721_NO_DATA_POOL_ID,
         from: IDENTITY,
       };
 
@@ -763,7 +763,7 @@ describe('TokensService', () => {
       await service.createPool(request).then(resp => {
         expect(resp).toEqual({
           data: `{"tx":${TX}}`,
-          poolId: ERC721_WITH_DATA_POOL_ID,
+          poolLocator: ERC721_WITH_DATA_POOL_ID,
           standard: 'ERC721',
           type: 'nonfungible',
           symbol: SYMBOL,
@@ -792,7 +792,7 @@ describe('TokensService', () => {
       await service.createPool(request).then(resp => {
         expect(resp).toEqual({
           data: `{"tx":${TX}}`,
-          poolId: ERC721_WITH_DATA_POOL_ID,
+          poolLocator: ERC721_WITH_DATA_POOL_ID,
           standard: 'ERC721',
           type: 'nonfungible',
           symbol: SYMBOL,
@@ -807,7 +807,7 @@ describe('TokensService', () => {
 
     it('should activate ERC721WithData pool correctly and return correct values', async () => {
       const request: TokenPoolActivate = {
-        poolId: ERC721_WITH_DATA_POOL_ID,
+        poolLocator: ERC721_WITH_DATA_POOL_ID,
       };
 
       const mockEventStream: EventStream = {
@@ -816,7 +816,7 @@ describe('TokensService', () => {
       };
 
       const response: TokenPoolEvent = {
-        poolId: ERC721_WITH_DATA_POOL_ID,
+        poolLocator: ERC721_WITH_DATA_POOL_ID,
         standard: 'ERC721',
         type: TokenType.NONFUNGIBLE,
         symbol: SYMBOL,
@@ -853,7 +853,7 @@ describe('TokensService', () => {
         amount: '2',
         tokenIndex: '721',
         signer: IDENTITY,
-        poolId: ERC721_WITH_DATA_POOL_ID,
+        poolLocator: ERC721_WITH_DATA_POOL_ID,
         to: '0x123',
       };
       await expect(service.mint(request)).rejects.toThrowError(
@@ -865,7 +865,7 @@ describe('TokensService', () => {
       const request: TokenMint = {
         tokenIndex: '721',
         signer: IDENTITY,
-        poolId: ERC721_WITH_DATA_POOL_ID,
+        poolLocator: ERC721_WITH_DATA_POOL_ID,
         to: '0x123',
       };
 
@@ -895,7 +895,7 @@ describe('TokensService', () => {
       const request: TokenTransfer = {
         tokenIndex: '721',
         signer: IDENTITY,
-        poolId: ERC721_WITH_DATA_POOL_ID,
+        poolLocator: ERC721_WITH_DATA_POOL_ID,
         from: IDENTITY,
         to: '0x123',
       };
@@ -928,7 +928,7 @@ describe('TokensService', () => {
       const request: TokenBurn = {
         tokenIndex: '721',
         signer: IDENTITY,
-        poolId: ERC721_WITH_DATA_POOL_ID,
+        poolLocator: ERC721_WITH_DATA_POOL_ID,
         from: IDENTITY,
       };
 
@@ -958,19 +958,19 @@ describe('TokensService', () => {
   describe('Miscellaneous', () => {
     it('should throw 404 exception if ABI method is not found when activating pool', async () => {
       const request: TokenPoolActivate = {
-        poolId: 'address=0x123&standard=notAStandard&type=fungible',
+        poolLocator: 'address=0x123&standard=notAStandard&type=fungible',
       };
       await expect(service.activatePool(request)).rejects.toThrowError(
         new HttpException('Transfer event ABI not found', HttpStatus.NOT_FOUND),
       );
     });
 
-    it('should throw 400 exception if poolID is malformed when activating pool', async () => {
+    it('should throw 400 exception if locator is malformed when activating pool', async () => {
       const request: TokenPoolActivate = {
-        poolId: 'address=0x123&type=fungible',
+        poolLocator: 'address=0x123&type=fungible',
       };
       await expect(service.activatePool(request)).rejects.toThrowError(
-        new HttpException('Invalid poolId', HttpStatus.BAD_REQUEST),
+        new HttpException('Invalid pool locator', HttpStatus.BAD_REQUEST),
       );
     });
 

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -749,7 +749,7 @@ class TokenListener implements EventListener {
     const blockchainId = this.formatBlockchainEventId(event);
     const poolId = unpackPoolId(unpackedSub.poolId);
     const commonData = {
-      id: blockchainId,
+      subject: blockchainId,
       poolId: unpackedSub.poolId,
       amount: poolId.type === TokenType.FUNGIBLE ? output.value : '1',
       signer: event.inputSigner,
@@ -813,20 +813,20 @@ class TokenListener implements EventListener {
     }
     const poolId = unpackPoolId(unpackedSub.poolId);
 
-    let id: string | undefined;
+    let subject: string | undefined;
     let approved = true;
     if (poolId.type === TokenType.FUNGIBLE) {
-      id = `${output.owner}:${output.spender}`;
+      subject = `${output.owner}:${output.spender}`;
       approved = BigInt(output.value ?? 0) > BigInt(0);
     } else {
-      id = output.tokenId;
+      subject = output.tokenId;
       approved = output.spender !== ZERO_ADDRESS;
     }
 
     return {
       event: 'token-approval',
       data: <TokenApprovalEvent>{
-        id,
+        subject,
         type: poolId.type,
         poolId: unpackedSub.poolId,
         operator: output.spender,
@@ -870,7 +870,7 @@ class TokenListener implements EventListener {
     return {
       event: 'token-approval',
       data: <TokenApprovalEvent>{
-        id: `${output.owner}:${output.operator}`,
+        subject: `${output.owner}:${output.operator}`,
         type: poolId.type,
         poolId: unpackedSub.poolId,
         operator: output.operator,

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -708,8 +708,11 @@ class TokenListener implements EventListener {
     }
   }
 
+  /**
+   * Generate an event ID in the recognized FireFly format for Ethereum
+   * (zero-padded block number, transaction index, and log index)
+   */
   private formatBlockchainEventId(event: Event) {
-    // This intentionally matches the formatting of protocol IDs for blockchain events in FireFly core
     const blockNumber = event.blockNumber ?? '0';
     const txIndex = BigInt(event.transactionIndex).toString(10);
     const logIndex = event.logIndex ?? '0';
@@ -741,16 +744,16 @@ class TokenListener implements EventListener {
       return undefined;
     }
 
-    const blockchainId = this.formatBlockchainEventId(event);
+    const eventId = this.formatBlockchainEventId(event);
     const poolLocator = unpackPoolLocator(unpackedSub.poolLocator);
     const commonData = {
-      subject: blockchainId,
+      id: eventId,
       poolLocator: unpackedSub.poolLocator,
       amount: poolLocator.type === TokenType.FUNGIBLE ? output.value : '1',
       signer: event.inputSigner,
       data: decodedData,
       blockchain: {
-        id: blockchainId,
+        id: eventId,
         name: this.stripParamsFromSignature(event.signature),
         location: 'address=' + event.address,
         signature: event.signature,
@@ -818,9 +821,11 @@ class TokenListener implements EventListener {
       approved = output.spender !== ZERO_ADDRESS;
     }
 
+    const eventId = this.formatBlockchainEventId(event);
     return {
       event: 'token-approval',
       data: <TokenApprovalEvent>{
+        id: eventId,
         subject,
         type: poolLocator.type,
         poolLocator: unpackedSub.poolLocator,
@@ -829,7 +834,7 @@ class TokenListener implements EventListener {
         signer: output.owner,
         data: decodedData,
         blockchain: {
-          id: this.formatBlockchainEventId(event),
+          id: eventId,
           name: this.stripParamsFromSignature(event.signature),
           location: 'address=' + event.address,
           signature: event.signature,
@@ -862,9 +867,11 @@ class TokenListener implements EventListener {
     }
     const poolLocator = unpackPoolLocator(unpackedSub.poolLocator);
 
+    const eventId = this.formatBlockchainEventId(event);
     return {
       event: 'token-approval',
       data: <TokenApprovalEvent>{
+        id: eventId,
         subject: `${output.owner}:${output.operator}`,
         type: poolLocator.type,
         poolLocator: unpackedSub.poolLocator,
@@ -873,7 +880,7 @@ class TokenListener implements EventListener {
         signer: output.owner,
         data: decodedData,
         blockchain: {
-          id: this.formatBlockchainEventId(event),
+          id: eventId,
           name: this.stripParamsFromSignature(event.signature),
           location: 'address=' + event.address,
           signature: event.signature,

--- a/src/tokens/tokens.util.spec.ts
+++ b/src/tokens/tokens.util.spec.ts
@@ -14,13 +14,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ITokenPool, TokenType } from './tokens.interfaces';
+import { IPoolLocator, TokenType } from './tokens.interfaces';
 import {
   decodeHex,
   encodeHex,
-  packPoolId,
+  packPoolLocator,
   packSubscriptionName,
-  unpackPoolId,
+  unpackPoolLocator,
   unpackSubscriptionName,
 } from './tokens.util';
 
@@ -56,23 +56,23 @@ describe('Util', () => {
   it('unpackSubscriptionName', () => {
     expect(unpackSubscriptionName('token', 'token:0x123456')).toEqual({
       prefix: 'token',
-      poolId: '0x123456',
+      poolLocator: '0x123456',
     });
     expect(unpackSubscriptionName('token', 'token:0x123456:create')).toEqual({
       prefix: 'token',
-      poolId: '0x123456',
+      poolLocator: '0x123456',
       event: 'create',
     });
     expect(unpackSubscriptionName('tok:en', 'tok:en:0x123456:create')).toEqual({
       prefix: 'tok:en',
-      poolId: '0x123456',
+      poolLocator: '0x123456',
       event: 'create',
     });
   });
 
-  it('packPoolId', () => {
+  it('packPoolLocator', () => {
     expect(
-      packPoolId({
+      packPoolLocator({
         address: '0x12345',
         schema: 'ERC20WithData',
         type: TokenType.FUNGIBLE,
@@ -80,15 +80,17 @@ describe('Util', () => {
     ).toEqual('address=0x12345&schema=ERC20WithData&type=fungible');
   });
 
-  it('unpackPoolId', () => {
-    expect(unpackPoolId('address=0x12345&schema=ERC20WithData&type=fungible')).toEqual(<ITokenPool>{
+  it('unpackPoolLocator', () => {
+    expect(unpackPoolLocator('address=0x12345&schema=ERC20WithData&type=fungible')).toEqual(<
+      IPoolLocator
+    >{
       address: '0x12345',
       schema: 'ERC20WithData',
       type: TokenType.FUNGIBLE,
     });
 
-    expect(unpackPoolId('address=0x12345&standard=ERC20WithData&type=fungible')).toEqual(<
-      ITokenPool
+    expect(unpackPoolLocator('address=0x12345&standard=ERC20WithData&type=fungible')).toEqual(<
+      IPoolLocator
     >{
       address: '0x12345',
       schema: 'ERC20WithData',

--- a/src/tokens/tokens.util.ts
+++ b/src/tokens/tokens.util.ts
@@ -58,6 +58,13 @@ export function unpackSubscriptionName(prefix: string, data: string) {
   };
 }
 
+/**
+ * Given a pool locator object, create a packed string representation.
+ *
+ * This should only be called once when the pool is first created! You should
+ * never re-pack a locator during event or request processing (always send
+ * back the one provided as input or unpacked from the subscription).
+ */
 export function packPoolLocator(locator: IValidPoolLocator) {
   const encoded = new URLSearchParams({
     [EncodedPoolLocatorEnum.Address]: locator.address,
@@ -67,6 +74,9 @@ export function packPoolLocator(locator: IValidPoolLocator) {
   return encoded.toString();
 }
 
+/**
+ * Unpack a pool locator string into its meaningful parts.
+ */
 export function unpackPoolLocator(data: string): IPoolLocator {
   const encoded = new URLSearchParams(data);
   return {

--- a/src/tokens/tokens.util.ts
+++ b/src/tokens/tokens.util.ts
@@ -14,7 +14,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { EncodedPoolIdEnum, ITokenPool, IValidTokenPool, TokenType } from './tokens.interfaces';
+import {
+  EncodedPoolLocatorEnum,
+  IPoolLocator,
+  IValidPoolLocator,
+  TokenType,
+} from './tokens.interfaces';
 
 /**
  * Encode a UTF-8 string into hex bytes with a leading 0x
@@ -48,26 +53,26 @@ export function unpackSubscriptionName(prefix: string, data: string) {
     : undefined;
   return {
     prefix,
-    poolId: parts?.[0],
+    poolLocator: parts?.[0],
     event: parts?.[1],
   };
 }
 
-export function packPoolId(poolId: IValidTokenPool) {
-  const encodedPoolId = new URLSearchParams({
-    [EncodedPoolIdEnum.Address]: poolId.address,
-    [EncodedPoolIdEnum.Schema]: poolId.schema,
-    [EncodedPoolIdEnum.Type]: poolId.type,
+export function packPoolLocator(locator: IValidPoolLocator) {
+  const encoded = new URLSearchParams({
+    [EncodedPoolLocatorEnum.Address]: locator.address,
+    [EncodedPoolLocatorEnum.Schema]: locator.schema,
+    [EncodedPoolLocatorEnum.Type]: locator.type,
   });
-  return encodedPoolId.toString();
+  return encoded.toString();
 }
 
-export function unpackPoolId(data: string): ITokenPool {
-  const encodedPoolId = new URLSearchParams(data);
+export function unpackPoolLocator(data: string): IPoolLocator {
+  const encoded = new URLSearchParams(data);
   return {
-    address: encodedPoolId.get(EncodedPoolIdEnum.Address),
+    address: encoded.get(EncodedPoolLocatorEnum.Address),
     schema:
-      encodedPoolId.get(EncodedPoolIdEnum.Schema) ?? encodedPoolId.get(EncodedPoolIdEnum.Standard),
-    type: encodedPoolId.get(EncodedPoolIdEnum.Type) as TokenType,
+      encoded.get(EncodedPoolLocatorEnum.Schema) ?? encoded.get(EncodedPoolLocatorEnum.Standard),
+    type: encoded.get(EncodedPoolLocatorEnum.Type) as TokenType,
   };
 }

--- a/test/erc20.e2e-spec.ts
+++ b/test/erc20.e2e-spec.ts
@@ -166,7 +166,7 @@ describe('ERC20 - e2e', () => {
 
       const expectedResponse = expect.objectContaining(<TokenPoolEvent>{
         data: `{"tx":${TX}}`,
-        poolId: `address=${CONTRACT_ADDRESS}&schema=${ERC20_WITH_DATA_SCHEMA}&type=${TokenType.FUNGIBLE}`,
+        poolLocator: `address=${CONTRACT_ADDRESS}&schema=${ERC20_WITH_DATA_SCHEMA}&type=${TokenType.FUNGIBLE}`,
         standard: 'ERC20',
         type: TokenType.FUNGIBLE,
         symbol: SYMBOL,
@@ -218,7 +218,7 @@ describe('ERC20 - e2e', () => {
 
       const expectedResponse = expect.objectContaining(<TokenPoolEvent>{
         data: `{"tx":${TX}}`,
-        poolId: `address=${CONTRACT_ADDRESS}&schema=${ERC20_WITH_DATA_SCHEMA}&type=${TokenType.FUNGIBLE}`,
+        poolLocator: `address=${CONTRACT_ADDRESS}&schema=${ERC20_WITH_DATA_SCHEMA}&type=${TokenType.FUNGIBLE}`,
         standard: 'ERC20',
         type: TokenType.FUNGIBLE,
         symbol: SYMBOL,
@@ -249,7 +249,7 @@ describe('ERC20 - e2e', () => {
 
       const expectedResponse = expect.objectContaining(<TokenPoolEvent>{
         data: `{"tx":${TX}}`,
-        poolId: `address=${CONTRACT_ADDRESS}&schema=${ERC20_WITH_DATA_SCHEMA}&type=${TokenType.FUNGIBLE}`,
+        poolLocator: `address=${CONTRACT_ADDRESS}&schema=${ERC20_WITH_DATA_SCHEMA}&type=${TokenType.FUNGIBLE}`,
         standard: 'ERC20',
         type: TokenType.FUNGIBLE,
         symbol: SYMBOL,
@@ -271,7 +271,7 @@ describe('ERC20 - e2e', () => {
       const request: TokenMint = {
         amount: '20',
         signer: IDENTITY,
-        poolId: ERC20_WITH_DATA_POOL_ID,
+        poolLocator: ERC20_WITH_DATA_POOL_ID,
         to: '0x123',
       };
 
@@ -302,7 +302,7 @@ describe('ERC20 - e2e', () => {
       const request: TokenTransfer = {
         amount: '20',
         signer: IDENTITY,
-        poolId: ERC20_WITH_DATA_POOL_ID,
+        poolLocator: ERC20_WITH_DATA_POOL_ID,
         to: '0x123',
         from: IDENTITY,
       };
@@ -336,7 +336,7 @@ describe('ERC20 - e2e', () => {
       const request: TokenBurn = {
         amount: '20',
         signer: IDENTITY,
-        poolId: ERC20_WITH_DATA_POOL_ID,
+        poolLocator: ERC20_WITH_DATA_POOL_ID,
         from: IDENTITY,
       };
 
@@ -379,7 +379,7 @@ describe('ERC20 - e2e', () => {
 
       const expectedResponse = expect.objectContaining(<TokenPoolEvent>{
         data: `{"tx":${TX}}`,
-        poolId: `address=${CONTRACT_ADDRESS}&schema=${ERC20_NO_DATA_SCHEMA}&type=${TokenType.FUNGIBLE}`,
+        poolLocator: `address=${CONTRACT_ADDRESS}&schema=${ERC20_NO_DATA_SCHEMA}&type=${TokenType.FUNGIBLE}`,
         standard: 'ERC20',
         type: TokenType.FUNGIBLE,
         symbol: SYMBOL,
@@ -430,7 +430,7 @@ describe('ERC20 - e2e', () => {
 
       const expectedResponse = expect.objectContaining(<TokenPoolEvent>{
         data: `{"tx":${TX}}`,
-        poolId: `address=${CONTRACT_ADDRESS}&schema=${ERC20_NO_DATA_SCHEMA}&type=${TokenType.FUNGIBLE}`,
+        poolLocator: `address=${CONTRACT_ADDRESS}&schema=${ERC20_NO_DATA_SCHEMA}&type=${TokenType.FUNGIBLE}`,
         standard: 'ERC20',
         type: TokenType.FUNGIBLE,
         symbol: SYMBOL,
@@ -452,7 +452,7 @@ describe('ERC20 - e2e', () => {
       const request: TokenMint = {
         amount: '20',
         signer: IDENTITY,
-        poolId: ERC20_NO_DATA_POOL_ID,
+        poolLocator: ERC20_NO_DATA_POOL_ID,
         to: '0x123',
       };
 
@@ -483,7 +483,7 @@ describe('ERC20 - e2e', () => {
       const request: TokenTransfer = {
         amount: '20',
         signer: IDENTITY,
-        poolId: ERC20_NO_DATA_POOL_ID,
+        poolLocator: ERC20_NO_DATA_POOL_ID,
         to: '0x123',
         from: IDENTITY,
       };
@@ -515,7 +515,7 @@ describe('ERC20 - e2e', () => {
       const request: TokenBurn = {
         amount: '20',
         signer: IDENTITY,
-        poolId: ERC20_NO_DATA_POOL_ID,
+        poolLocator: ERC20_NO_DATA_POOL_ID,
         from: IDENTITY,
       };
 

--- a/test/erc721.e2e-spec.ts
+++ b/test/erc721.e2e-spec.ts
@@ -164,7 +164,7 @@ describe('ERC721 - e2e', () => {
 
       const expectedResponse = expect.objectContaining(<TokenPoolEvent>{
         data: `{"tx":${TX}}`,
-        poolId: `address=${CONTRACT_ADDRESS}&schema=${ERC721_WITH_DATA_SCHEMA}&type=${TokenType.NONFUNGIBLE}`,
+        poolLocator: `address=${CONTRACT_ADDRESS}&schema=${ERC721_WITH_DATA_SCHEMA}&type=${TokenType.NONFUNGIBLE}`,
         standard: 'ERC721',
         type: TokenType.NONFUNGIBLE,
         symbol: SYMBOL,
@@ -195,7 +195,7 @@ describe('ERC721 - e2e', () => {
 
       const expectedResponse = expect.objectContaining(<TokenPoolEvent>{
         data: `{"tx":${TX}}`,
-        poolId: `address=${CONTRACT_ADDRESS}&schema=${ERC721_WITH_DATA_SCHEMA}&type=${TokenType.NONFUNGIBLE}`,
+        poolLocator: `address=${CONTRACT_ADDRESS}&schema=${ERC721_WITH_DATA_SCHEMA}&type=${TokenType.NONFUNGIBLE}`,
         standard: 'ERC721',
         type: TokenType.NONFUNGIBLE,
         symbol: SYMBOL,
@@ -217,7 +217,7 @@ describe('ERC721 - e2e', () => {
       const request: TokenMint = {
         tokenIndex: '721',
         signer: IDENTITY,
-        poolId: ERC721_WITH_DATA_POOL_ID,
+        poolLocator: ERC721_WITH_DATA_POOL_ID,
         to: '0x123',
       };
 
@@ -250,7 +250,7 @@ describe('ERC721 - e2e', () => {
       const request: TokenTransfer = {
         tokenIndex: '721',
         signer: IDENTITY,
-        poolId: ERC721_WITH_DATA_POOL_ID,
+        poolLocator: ERC721_WITH_DATA_POOL_ID,
         to: '0x123',
         from: IDENTITY,
       };
@@ -284,7 +284,7 @@ describe('ERC721 - e2e', () => {
       const request: TokenBurn = {
         tokenIndex: '721',
         signer: IDENTITY,
-        poolId: ERC721_WITH_DATA_POOL_ID,
+        poolLocator: ERC721_WITH_DATA_POOL_ID,
         from: IDENTITY,
       };
 
@@ -328,7 +328,7 @@ describe('ERC721 - e2e', () => {
 
       const expectedResponse = expect.objectContaining(<TokenPoolEvent>{
         data: `{"tx":${TX}}`,
-        poolId: `address=${CONTRACT_ADDRESS}&schema=${ERC721_NO_DATA_SCHEMA}&type=${TokenType.NONFUNGIBLE}`,
+        poolLocator: `address=${CONTRACT_ADDRESS}&schema=${ERC721_NO_DATA_SCHEMA}&type=${TokenType.NONFUNGIBLE}`,
         standard: 'ERC721',
         type: TokenType.NONFUNGIBLE,
         symbol: SYMBOL,
@@ -350,7 +350,7 @@ describe('ERC721 - e2e', () => {
       const request: TokenMint = {
         tokenIndex: '721',
         signer: IDENTITY,
-        poolId: ERC721_NO_DATA_POOL_ID,
+        poolLocator: ERC721_NO_DATA_POOL_ID,
         to: '0x123',
       };
 
@@ -381,7 +381,7 @@ describe('ERC721 - e2e', () => {
       const request: TokenTransfer = {
         tokenIndex: '721',
         signer: IDENTITY,
-        poolId: ERC721_NO_DATA_POOL_ID,
+        poolLocator: ERC721_NO_DATA_POOL_ID,
         to: '0x123',
         from: IDENTITY,
       };
@@ -415,7 +415,7 @@ describe('ERC721 - e2e', () => {
       const request: TokenBurn = {
         tokenIndex: '721',
         signer: IDENTITY,
-        poolId: ERC721_NO_DATA_POOL_ID,
+        poolLocator: ERC721_NO_DATA_POOL_ID,
         from: IDENTITY,
       };
 

--- a/test/ws.e2e-spec.ts
+++ b/test/ws.e2e-spec.ts
@@ -210,7 +210,7 @@ describe('WebSocket AppController (e2e)', () => {
       event: 'token-mint',
       data: <TokenMintEvent>{
         subject: '000000000001/000000/000001',
-        poolId: ERC20_POOL_ID,
+        poolLocator: ERC20_POOL_ID,
         to: 'A',
         amount: '5',
         signer: IDENTITY,
@@ -252,7 +252,7 @@ describe('WebSocket AppController (e2e)', () => {
       });
   });
 
-  it('Websocket: ERC20 token mint event with old poolId', async () => {
+  it('Websocket: ERC20 token mint event with old locator', async () => {
     eventstream.getSubscription.mockReturnValueOnce(<EventStreamSubscription>{
       name:
         TOPIC +
@@ -264,7 +264,7 @@ describe('WebSocket AppController (e2e)', () => {
       event: 'token-mint',
       data: <TokenMintEvent>{
         subject: '000000000001/000000/000001',
-        poolId: `address=${CONTRACT_ADDRESS}&standard=${ERC20_STANDARD}&type=${TokenType.FUNGIBLE}`,
+        poolLocator: `address=${CONTRACT_ADDRESS}&standard=${ERC20_STANDARD}&type=${TokenType.FUNGIBLE}`,
         to: 'A',
         amount: '5',
         signer: IDENTITY,
@@ -345,7 +345,7 @@ describe('WebSocket AppController (e2e)', () => {
       event: 'token-mint',
       data: <TokenMintEvent>{
         subject: '000000000001/000000/000001',
-        poolId: ERC721_POOL_ID,
+        poolLocator: ERC721_POOL_ID,
         to: 'A',
         amount: '1',
         signer: IDENTITY,
@@ -398,7 +398,7 @@ describe('WebSocket AppController (e2e)', () => {
       event: 'token-transfer',
       data: <TokenTransferEvent>{
         subject: '000000000001/000000/000001',
-        poolId: ERC20_POOL_ID,
+        poolLocator: ERC20_POOL_ID,
         from: 'A',
         to: 'B',
         amount: '5',
@@ -481,7 +481,7 @@ describe('WebSocket AppController (e2e)', () => {
       event: 'token-transfer',
       data: <TokenTransferEvent>{
         subject: '000000000001/000000/000001',
-        poolId: ERC721_POOL_ID,
+        poolLocator: ERC721_POOL_ID,
         from: 'A',
         to: 'B',
         amount: '1',
@@ -535,7 +535,7 @@ describe('WebSocket AppController (e2e)', () => {
       event: 'token-burn',
       data: <TokenBurnEvent>{
         subject: '000000000001/000000/000001',
-        poolId: ERC20_POOL_ID,
+        poolLocator: ERC20_POOL_ID,
         from: 'B',
         amount: '5',
         signer: IDENTITY,
@@ -616,7 +616,7 @@ describe('WebSocket AppController (e2e)', () => {
       event: 'token-burn',
       data: <TokenBurnEvent>{
         subject: '000000000001/000000/000001',
-        poolId: ERC721_POOL_ID,
+        poolLocator: ERC721_POOL_ID,
         from: 'B',
         amount: '1',
         signer: IDENTITY,

--- a/test/ws.e2e-spec.ts
+++ b/test/ws.e2e-spec.ts
@@ -209,7 +209,7 @@ describe('WebSocket AppController (e2e)', () => {
     const mockMintWebSocketMessage: WebSocketMessage = {
       event: 'token-mint',
       data: <TokenMintEvent>{
-        subject: '000000000001/000000/000001',
+        id: '000000000001/000000/000001',
         poolLocator: ERC20_POOL_ID,
         to: 'A',
         amount: '5',
@@ -263,7 +263,7 @@ describe('WebSocket AppController (e2e)', () => {
     const mockMintWebSocketMessage: WebSocketMessage = {
       event: 'token-mint',
       data: <TokenMintEvent>{
-        subject: '000000000001/000000/000001',
+        id: '000000000001/000000/000001',
         poolLocator: `address=${CONTRACT_ADDRESS}&standard=${ERC20_STANDARD}&type=${TokenType.FUNGIBLE}`,
         to: 'A',
         amount: '5',
@@ -344,7 +344,7 @@ describe('WebSocket AppController (e2e)', () => {
     const mockMintWebSocketMessage: WebSocketMessage = {
       event: 'token-mint',
       data: <TokenMintEvent>{
-        subject: '000000000001/000000/000001',
+        id: '000000000001/000000/000001',
         poolLocator: ERC721_POOL_ID,
         to: 'A',
         amount: '1',
@@ -397,7 +397,7 @@ describe('WebSocket AppController (e2e)', () => {
     const mockTransferWebSocketMessage: WebSocketMessage = {
       event: 'token-transfer',
       data: <TokenTransferEvent>{
-        subject: '000000000001/000000/000001',
+        id: '000000000001/000000/000001',
         poolLocator: ERC20_POOL_ID,
         from: 'A',
         to: 'B',
@@ -480,7 +480,7 @@ describe('WebSocket AppController (e2e)', () => {
     const mockTransferWebSocketMessage: WebSocketMessage = {
       event: 'token-transfer',
       data: <TokenTransferEvent>{
-        subject: '000000000001/000000/000001',
+        id: '000000000001/000000/000001',
         poolLocator: ERC721_POOL_ID,
         from: 'A',
         to: 'B',
@@ -534,7 +534,7 @@ describe('WebSocket AppController (e2e)', () => {
     const mockBurnWebSocketMessage: WebSocketMessage = {
       event: 'token-burn',
       data: <TokenBurnEvent>{
-        subject: '000000000001/000000/000001',
+        id: '000000000001/000000/000001',
         poolLocator: ERC20_POOL_ID,
         from: 'B',
         amount: '5',
@@ -615,7 +615,7 @@ describe('WebSocket AppController (e2e)', () => {
     const mockBurnWebSocketMessage: WebSocketMessage = {
       event: 'token-burn',
       data: <TokenBurnEvent>{
-        subject: '000000000001/000000/000001',
+        id: '000000000001/000000/000001',
         poolLocator: ERC721_POOL_ID,
         from: 'B',
         amount: '1',

--- a/test/ws.e2e-spec.ts
+++ b/test/ws.e2e-spec.ts
@@ -209,7 +209,7 @@ describe('WebSocket AppController (e2e)', () => {
     const mockMintWebSocketMessage: WebSocketMessage = {
       event: 'token-mint',
       data: <TokenMintEvent>{
-        id: '000000000001/000000/000001',
+        subject: '000000000001/000000/000001',
         poolId: ERC20_POOL_ID,
         to: 'A',
         amount: '5',
@@ -263,7 +263,7 @@ describe('WebSocket AppController (e2e)', () => {
     const mockMintWebSocketMessage: WebSocketMessage = {
       event: 'token-mint',
       data: <TokenMintEvent>{
-        id: '000000000001/000000/000001',
+        subject: '000000000001/000000/000001',
         poolId: `address=${CONTRACT_ADDRESS}&standard=${ERC20_STANDARD}&type=${TokenType.FUNGIBLE}`,
         to: 'A',
         amount: '5',
@@ -344,7 +344,7 @@ describe('WebSocket AppController (e2e)', () => {
     const mockMintWebSocketMessage: WebSocketMessage = {
       event: 'token-mint',
       data: <TokenMintEvent>{
-        id: '000000000001/000000/000001',
+        subject: '000000000001/000000/000001',
         poolId: ERC721_POOL_ID,
         to: 'A',
         amount: '1',
@@ -397,7 +397,7 @@ describe('WebSocket AppController (e2e)', () => {
     const mockTransferWebSocketMessage: WebSocketMessage = {
       event: 'token-transfer',
       data: <TokenTransferEvent>{
-        id: '000000000001/000000/000001',
+        subject: '000000000001/000000/000001',
         poolId: ERC20_POOL_ID,
         from: 'A',
         to: 'B',
@@ -480,7 +480,7 @@ describe('WebSocket AppController (e2e)', () => {
     const mockTransferWebSocketMessage: WebSocketMessage = {
       event: 'token-transfer',
       data: <TokenTransferEvent>{
-        id: '000000000001/000000/000001',
+        subject: '000000000001/000000/000001',
         poolId: ERC721_POOL_ID,
         from: 'A',
         to: 'B',
@@ -534,7 +534,7 @@ describe('WebSocket AppController (e2e)', () => {
     const mockBurnWebSocketMessage: WebSocketMessage = {
       event: 'token-burn',
       data: <TokenBurnEvent>{
-        id: '000000000001/000000/000001',
+        subject: '000000000001/000000/000001',
         poolId: ERC20_POOL_ID,
         from: 'B',
         amount: '5',
@@ -615,7 +615,7 @@ describe('WebSocket AppController (e2e)', () => {
     const mockBurnWebSocketMessage: WebSocketMessage = {
       event: 'token-burn',
       data: <TokenBurnEvent>{
-        id: '000000000001/000000/000001',
+        subject: '000000000001/000000/000001',
         poolId: ERC721_POOL_ID,
         from: 'B',
         amount: '1',


### PR DESCRIPTION
Token pools now have a "locator" instead of an "id".

The thing that was called "id" on approvals is now "subject", and they also have a new "id" that matches the format of the one on transfers.