### PR TITLE
Support custom URI's for ERC721WithData Contract

### DIFF
--- a/samples/solidity/contracts/ERC721WithData.sol
+++ b/samples/solidity/contracts/ERC721WithData.sol
@@ -15,7 +15,7 @@ import './IERC721WithData.sol';
  *   - the contract owner (ie deployer) is the only party allowed to mint
  *   - any party can approve another party to manage (ie transfer) some or all of their tokens
  *   - any party can burn their own tokens
- *   - token URIs are hard-coded to "firefly://token/{id}"
+ *   - token URIs are customizable when minting, but default to "firefly://token/{id}"
  *
  * The inclusion of a "data" argument on each external method allows FireFly to write
  * extra data to the chain alongside each token transaction, in order to correlate it with
@@ -58,7 +58,7 @@ contract ERC721WithData is Context, Ownable, ERC721, IERC721WithData {
         uint256 tokenId,
         bytes calldata data,
         string memory tokenURI_
-    ) external {
+    ) external onlyOwner {
         _safeMint(to, tokenId, data);
 
         // If there is no tokenURI passed, concatenate the tokenID to the base URI
@@ -120,7 +120,7 @@ contract ERC721WithData is Context, Ownable, ERC721, IERC721WithData {
         return uri;
     }
 
-    function _setTokenURI(uint256 tokenId, string memory _tokenURI) internal virtual {
+    function _setTokenURI(uint256 tokenId, string memory _tokenURI) internal onlyOwner {
         require(_exists(tokenId), "ERC721WithData: Token does not exist");
         _tokenURIs[tokenId] = _tokenURI;
     }

--- a/samples/solidity/contracts/ERC721WithData.sol
+++ b/samples/solidity/contracts/ERC721WithData.sol
@@ -58,7 +58,7 @@ contract ERC721WithData is Context, Ownable, ERC721, IERC721WithData {
         uint256 tokenId,
         bytes calldata data,
         string memory tokenURI_
-    ) external onlyOwner {
+    ) external override onlyOwner {
         _safeMint(to, tokenId, data);
 
         // If there is no tokenURI passed, concatenate the tokenID to the base URI

--- a/samples/solidity/contracts/IERC721WithData.sol
+++ b/samples/solidity/contracts/IERC721WithData.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 import '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 
 /**
- * ERC721 interface with mint, burn, and attached data support.
+ * ERC721 interface with mint, burn, attached data, and custom URI support.
  *
  * The inclusion of a "data" argument on each external method allows FireFly to write
  * extra data to the chain alongside each token transaction, in order to correlate it with
@@ -16,6 +16,13 @@ interface IERC721WithData is IERC165 {
         address to,
         uint256 tokenId,
         bytes calldata data
+    ) external;
+
+    function mintWithURI(
+        address to,
+        uint256 tokenId,
+        bytes calldata data,
+        string memory tokenURI_
     ) external;
 
     function transferWithData(

--- a/samples/solidity/contracts/ITokenFactory.sol
+++ b/samples/solidity/contracts/ITokenFactory.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/contracts/utils/introspection/IERC165.sol';
+
+/**
+ * TokenFactory interface with data and custom URI support.
+ */
+
+interface ITokenFactory is IERC165 {
+  function create(
+    string memory name,
+    string memory symbol,
+    bool is_fungible,
+    bytes calldata data,
+    string memory uri
+  ) external;
+} 

--- a/samples/solidity/contracts/InterfaceCheck.sol
+++ b/samples/solidity/contracts/InterfaceCheck.sol
@@ -4,11 +4,16 @@ pragma solidity ^0.8.0;
 
 import './IERC20WithData.sol';
 import './IERC721WithData.sol';
+import './ITokenFactory.sol';
 
 /**
  * Test utility for checking ERC165 interface identifiers.
  */
 contract InterfaceCheck {
+    function tokenfactory() external view returns (bytes4) {
+        return type(ITokenFactory).interfaceId;
+    }
+
     function erc20WithData() external view returns (bytes4) {
         return type(IERC20WithData).interfaceId;
     }

--- a/samples/solidity/contracts/TokenFactory.sol
+++ b/samples/solidity/contracts/TokenFactory.sol
@@ -38,14 +38,15 @@ contract TokenFactory is Context {
         string memory name,
         string memory symbol,
         bool is_fungible,
-        bytes calldata data
+        bytes calldata data,
+        string memory uri
     ) external virtual {
         if (is_fungible) {
             ERC20WithData erc20 = new ERC20WithData(name, symbol);
             erc20.transferOwnership(_msgSender());
             emit TokenPoolCreation(address(erc20), name, symbol, true, data);
         } else {
-            ERC721WithData erc721 = new ERC721WithData(name, symbol);
+            ERC721WithData erc721 = new ERC721WithData(name, symbol, uri);
             erc721.transferOwnership(_msgSender());
             emit TokenPoolCreation(address(erc721), name, symbol, false, data);
         }

--- a/samples/solidity/contracts/TokenFactory.sol
+++ b/samples/solidity/contracts/TokenFactory.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.0;
 import '@openzeppelin/contracts/utils/Context.sol';
 import './ERC20WithData.sol';
 import './ERC721WithData.sol';
+import './ITokenFactory.sol';
 
 /**
  * Example TokenFactory for deploying simple ERC20 and ERC721 token contracts.
@@ -31,7 +32,7 @@ import './ERC721WithData.sol';
  * Finally, remember to always consult best practices from other communities and examples (such as OpenZeppelin)
  * when crafting your token logic, rather than relying on the FireFly community alone. Happy minting!
  */
-contract TokenFactory is Context {
+contract TokenFactory is Context, ITokenFactory {
     event TokenPoolCreation(address indexed contract_address, string name, string symbol, bool is_fungible, bytes data);
 
     function create(
@@ -40,7 +41,7 @@ contract TokenFactory is Context {
         bool is_fungible,
         bytes calldata data,
         string memory uri
-    ) external virtual {
+    ) external override virtual {
         if (is_fungible) {
             ERC20WithData erc20 = new ERC20WithData(name, symbol);
             erc20.transferOwnership(_msgSender());
@@ -50,5 +51,11 @@ contract TokenFactory is Context {
             erc721.transferOwnership(_msgSender());
             emit TokenPoolCreation(address(erc721), name, symbol, false, data);
         }
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(IERC165) returns (bool) {
+        return interfaceId == type(ITokenFactory).interfaceId;
     }
 }

--- a/samples/solidity/contracts/TokenFactory.sol
+++ b/samples/solidity/contracts/TokenFactory.sol
@@ -22,7 +22,7 @@ import './ERC721WithData.sol';
  * Just a few of the questions to consider when developing a contract for production:
  *   - is a factory pattern the best solution for your use case, or is a pre-deployed token contract more suitable?
  *   - is a proxy layer needed for contract upgradeability?
- *   - are other extension points beyond "name" and "symbol" needed (for instance "decimals", "uri", "supply")?
+ *   - are other extension points beyond "name", "symbol", and "uri" needed (for instance "decimals" or "supply")?
  *
  * See the FireFly documentation for descriptions of the various patterns supported for working with tokens.
  * Please also read the descriptions of the sample ERC20WithData and ERC721WithData contracts utilized by this

--- a/samples/solidity/test/ERC721WithData.ts
+++ b/samples/solidity/test/ERC721WithData.ts
@@ -22,6 +22,7 @@ describe('ERC721WithData - Unit Tests', function () {
     deployedERC721WithData = await Factory.connect(deployerSignerA).deploy(
       contractName,
       contractSymbol,
+      ""
     );
     await deployedERC721WithData.deployed();
   });
@@ -37,18 +38,19 @@ describe('ERC721WithData - Unit Tests', function () {
     expect(await deployedERC721WithData.symbol()).to.equal(contractSymbol);
   });
 
-  it('Mint - Deployer should mint tokens to itself successfully', async function () {
+  it('Mint - Should mint successfully with a custom URI', async function () {
     expect(await deployedERC721WithData.balanceOf(deployerSignerA.address)).to.equal(0);
     // Signer A mint token 721 to Signer A (Allowed)
     await expect(
       deployedERC721WithData
         .connect(deployerSignerA)
-        .mintWithData(deployerSignerA.address, 721, '0x00'),
+        .mintWithURI(deployerSignerA.address, 721, '0x00', "ipfs://CID"),
     )
       .to.emit(deployedERC721WithData, 'Transfer')
       .withArgs(ZERO_ADDRESS, deployerSignerA.address, 721);
 
     expect(await deployedERC721WithData.balanceOf(deployerSignerA.address)).to.equal(1);
+    expect(await deployedERC721WithData.tokenURI(721)).to.equal('ipfs://CID');
   });
 
   it('Mint - Non-deployer of contract should not be able to mint tokens', async function () {

--- a/samples/solidity/test/ERC721WithData.ts
+++ b/samples/solidity/test/ERC721WithData.ts
@@ -30,7 +30,7 @@ describe('ERC721WithData - Unit Tests', function () {
   it('Verify interface ID', async function () {
     const checkerFactory = await ethers.getContractFactory('InterfaceCheck');
     const checker: InterfaceCheck = await checkerFactory.connect(deployerSignerA).deploy();
-    expect(await checker.erc721WithData()).to.equal('0xb2429c12');
+    expect(await checker.erc721WithData()).to.equal('0xfd0771df');
   });
 
   it('Create - Should create a new ERC721 instance with default state', async function () {

--- a/samples/solidity/test/TokenFactory.ts
+++ b/samples/solidity/test/TokenFactory.ts
@@ -6,8 +6,6 @@ import { TokenFactory } from '../typechain';
 describe('TokenFactory - Unit Tests', function () {
   const contractName = 'testName';
   const contractSymbol = 'testSymbol';
-  const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
-  const ONE_ADDRESS = '0x1111111111111111111111111111111111111111';
   let deployedTokenFactory: TokenFactory;
   let Factory;
 
@@ -24,7 +22,7 @@ describe('TokenFactory - Unit Tests', function () {
   });
 
   it('Create - Should deploy a new ERC20 contract', async function () {
-    const tx = await deployedTokenFactory.create(contractName, contractSymbol, true, '0x00');
+    const tx = await deployedTokenFactory.create(contractName, contractSymbol, true, '0x00', '');
     expect(tx).to.emit(deployedTokenFactory, 'TokenPoolCreation');
     const receipt = await tx.wait();
     const event = receipt.events?.find(e => e.event === 'TokenPoolCreation');
@@ -37,7 +35,20 @@ describe('TokenFactory - Unit Tests', function () {
   });
 
   it('Create - Should deploy a new ERC721 contract', async function () {
-    const tx = await deployedTokenFactory.create(contractName, contractSymbol, false, '0x00');
+    const tx = await deployedTokenFactory.create(contractName, contractSymbol, false, '0x00', '');
+    expect(tx).to.emit(deployedTokenFactory, 'TokenPoolCreation');
+    const receipt = await tx.wait();
+    const event = receipt.events?.find(e => e.event === 'TokenPoolCreation');
+    expect(event).to.exist;
+    if (event) {
+      expect(event.args).to.have.length(5);
+      expect(event.args?.[0]).to.be.properAddress;
+      expect(event.args?.slice(1)).to.eql([contractName, contractSymbol, false, '0x00']);
+    }
+  });
+
+  it('Create - Should deploy a new ERC721 contract with a custom URI', async function () {
+    const tx = await deployedTokenFactory.create(contractName, contractSymbol, false, '0x00', 'testURI');
     expect(tx).to.emit(deployedTokenFactory, 'TokenPoolCreation');
     const receipt = await tx.wait();
     const event = receipt.events?.find(e => e.event === 'TokenPoolCreation');

--- a/samples/solidity/test/TokenFactory.ts
+++ b/samples/solidity/test/TokenFactory.ts
@@ -1,7 +1,7 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
-import { TokenFactory } from '../typechain';
+import { TokenFactory, InterfaceCheck } from '../typechain';
 
 describe('TokenFactory - Unit Tests', function () {
   const contractName = 'testName';
@@ -19,6 +19,12 @@ describe('TokenFactory - Unit Tests', function () {
     // Deploy token factory with Signer A
     deployedTokenFactory = await Factory.connect(deployerSignerA).deploy();
     await deployedTokenFactory.deployed();
+  });
+
+  it('Verify interface ID', async function () {
+    const checkerFactory = await ethers.getContractFactory('InterfaceCheck');
+    const checker: InterfaceCheck = await checkerFactory.connect(deployerSignerA).deploy();
+    expect(await checker.tokenfactory()).to.equal('0x83a74a0c');
   });
 
   it('Create - Should deploy a new ERC20 contract', async function () {


### PR DESCRIPTION
The ERC721WithData contract now supports custom token URI's on mint.

 - constructor now takes an optional baseURI string
 - new MintWithURI method that sets the URI for the provided token id