### PR TITLE
add `baseTokenUri` param to ERC721 hardhat deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,18 @@ $ npm run start:prod
 View the Swagger UI at http://localhost:3000/api<br />
 View the generated OpenAPI spec at http://localhost:3000/api-json
 
+## Manually deploy contracts
+
+To deploy both ERC20 and ERC721 contracts to a FireFly network, use the provided `deploy` script powered by [hardhat](https://github.com/NomicFoundation/hardhat).
+
+```bash
+cd samples/solidity
+npm install
+npm run deploy
+```
+
+Note: [firefly-cli](https://github.com/hyperledger/firefly-cli) will take care of contract deployment during stack creation.
+
 ## Testing
 
 ```bash

--- a/samples/solidity/scripts/deploy.ts
+++ b/samples/solidity/scripts/deploy.ts
@@ -20,7 +20,7 @@ async function main() {
   console.log('ERC-20 contract deployed to:', erc20.address);
 
   const ERC721 = await ethers.getContractFactory('ERC721WithData');
-  const erc721 = await ERC721.deploy('FFNFT', 'FFNFT');
+  const erc721 = await ERC721.deploy('FFNFT', 'FFNFT', "");
   await erc721.deployed();
   console.log('ERC-721 contract deployed to:', erc721.address);
 }


### PR DESCRIPTION
Deploys ERC721WithData with `baseTokenUri` set to an empty string, so the contract will use the default base URI of `firefly://token/`