### PR TITLE
🐛 BUG: Patched CVE-2022-24434 Crash in HeaderParser in dicer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2590,7 +2590,7 @@
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
       "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
       "requires": {
-        "dicer": "0.2.5",
+        "dicer": "0.3.1",
         "readable-stream": "1.1.x"
       }
     },
@@ -3093,8 +3093,8 @@
       }
     },
     "dicer": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.1.tgz",
       "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
       "requires": {
         "readable-stream": "1.1.x",


### PR DESCRIPTION
This affects all versions of package dicer. A malicious attacker can send a modified form to server, and crash the nodejs service. A complete denial of service can be achived by sending the malicious form in a loop.

**CVE-2022-24434**
`7.5/ 10`