### PR TITLE
Patch ProxyAgent vulnerable to MITM

### DIFF
--- a/samples/solidity/package-lock.json
+++ b/samples/solidity/package-lock.json
@@ -1004,7 +1004,7 @@
         "debug": "^4.1.1",
         "fs-extra": "^7.0.1",
         "semver": "^6.3.0",
-        "undici": "^4.14.1"
+        "undici": "^5.8.0"
       }
     },
     "@nomiclabs/hardhat-waffle": {
@@ -14146,7 +14146,7 @@
         "stacktrace-parser": "^0.1.10",
         "true-case-path": "^2.2.1",
         "tsort": "0.0.1",
-        "undici": "^4.14.1",
+        "undici": "^5.8.0",
         "uuid": "^8.3.2",
         "ws": "^7.4.6"
       },
@@ -18804,8 +18804,8 @@
       }
     },
     "undici": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.16.0.tgz",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.8.0.tgz",
       "integrity": "sha512-tkZSECUYi+/T1i4u+4+lwZmQgLXd4BLGlrc7KZPcLIW7Jpq99+Xpc30ONv7nS6F5UNOxp/HBZSSL9MafUrvJbw==",
       "dev": true
     },


### PR DESCRIPTION
## Description
`Undici.ProxyAgent` never verifies the remote server's certificate, and always exposes all request & response data to the proxy. This unexpectedly means that proxies can MitM all HTTPS traffic, and if the proxy's URL is HTTP then it also means that nominally HTTPS requests are actually sent via plain-text HTTP between Undici and the proxy server.

## Impact
This affects all use of HTTPS via HTTP proxy using `Undici.ProxyAgent` with Undici or Node's global `fetch`. In this case, it removes all HTTPS security from all requests sent using Undici's `ProxyAgent`, allowing trivial MitM attacks by anybody on the network path between the client and the target server (local network users, your ISP, the proxy, the target server's ISP, etc).
This less seriously affects HTTPS via HTTPS proxies. When you send HTTPS via a proxy to a remote server, the proxy can freely view or modify all HTTPS traffic unexpectedly (but only the proxy).

**CVE-2022-32210**
`7.7/ 10`
CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:C/C:H/I:H/A:N
