### PR TITLE
Patched Command Injection in lodash

### DIFF
--- a/samples/solidity/package-lock.json
+++ b/samples/solidity/package-lock.json
@@ -371,7 +371,7 @@
             "debug": "^4.1.1",
             "fs-extra": "^7.0.0",
             "js-sha3": "^0.8.0",
-            "lodash": "^4.17.15",
+            "lodash": "^4.17.21",
             "ts-essentials": "^6.0.3",
             "ts-generator": "^0.1.1"
           }
@@ -1368,7 +1368,7 @@
       "integrity": "sha512-jfcmlTvaaJjng63QsT49MT6R1HFhtO/TBMWbyzPFSzMmVIqb2tL6prnKBs4ZJrSvmgIXWy+ttSjpaxCTq8D/Tw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "ts-essentials": "^7.0.1"
       }
     },
@@ -2055,7 +2055,7 @@
       "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.21"
       }
     },
     "async-eventemitter": {
@@ -3858,7 +3858,7 @@
         "ethereum-cryptography": "^1.0.3",
         "ethers": "^4.0.40",
         "fs-readdir-recursive": "^1.1.0",
-        "lodash": "^4.17.14",
+        "lodash": "^4.17.21",
         "markdown-table": "^1.1.3",
         "mocha": "^7.1.1",
         "req-cwd": "^2.0.0",
@@ -4338,7 +4338,7 @@
           "dev": true,
           "requires": {
             "flat": "^4.1.0",
-            "lodash": "^4.17.15",
+            "lodash": "^4.17.21",
             "yargs": "^13.3.0"
           }
         }
@@ -4967,7 +4967,7 @@
         "keccak": "3.0.1",
         "level-sublevel": "6.6.4",
         "levelup": "3.1.1",
-        "lodash": "4.17.20",
+        "lodash": "4.17.21",
         "lru-cache": "5.1.1",
         "merkle-patricia-tree": "3.0.0",
         "patch-package": "6.2.2",
@@ -5381,7 +5381,7 @@
           "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.11"
+            "lodash": "^4.17.21"
           }
         },
         "async-eventemitter": {
@@ -5501,7 +5501,7 @@
             "convert-source-map": "^1.5.1",
             "debug": "^2.6.9",
             "json5": "^0.5.1",
-            "lodash": "^4.17.4",
+            "lodash": "^4.17.21",
             "minimatch": "^3.0.4",
             "path-is-absolute": "^1.0.1",
             "private": "^0.1.8",
@@ -5549,7 +5549,7 @@
             "babel-types": "^6.26.0",
             "detect-indent": "^4.0.0",
             "jsesc": "^1.3.0",
-            "lodash": "^4.17.4",
+            "lodash": "^4.17.21",
             "source-map": "^0.5.7",
             "trim-right": "^1.0.1"
           },
@@ -5594,7 +5594,7 @@
             "babel-helper-function-name": "^6.24.1",
             "babel-runtime": "^6.26.0",
             "babel-types": "^6.26.0",
-            "lodash": "^4.17.4"
+            "lodash": "^4.17.21"
           }
         },
         "babel-helper-explode-assignable-expression": {
@@ -5659,7 +5659,7 @@
           "requires": {
             "babel-runtime": "^6.26.0",
             "babel-types": "^6.26.0",
-            "lodash": "^4.17.4"
+            "lodash": "^4.17.21"
           }
         },
         "babel-helper-remap-async-to-generator": {
@@ -5774,7 +5774,7 @@
             "babel-template": "^6.26.0",
             "babel-traverse": "^6.26.0",
             "babel-types": "^6.26.0",
-            "lodash": "^4.17.4"
+            "lodash": "^4.17.21"
           }
         },
         "babel-plugin-transform-es2015-classes": {
@@ -6066,7 +6066,7 @@
             "babel-runtime": "^6.26.0",
             "core-js": "^2.5.0",
             "home-or-tmp": "^2.0.0",
-            "lodash": "^4.17.4",
+            "lodash": "^4.17.21",
             "mkdirp": "^0.5.1",
             "source-map-support": "^0.4.15"
           },
@@ -6102,7 +6102,7 @@
             "babel-traverse": "^6.26.0",
             "babel-types": "^6.26.0",
             "babylon": "^6.18.0",
-            "lodash": "^4.17.4"
+            "lodash": "^4.17.21"
           }
         },
         "babel-traverse": {
@@ -6119,7 +6119,7 @@
             "debug": "^2.6.8",
             "globals": "^9.18.0",
             "invariant": "^2.2.2",
-            "lodash": "^4.17.4"
+            "lodash": "^4.17.21"
           },
           "dependencies": {
             "debug": {
@@ -6153,7 +6153,7 @@
           "requires": {
             "babel-runtime": "^6.26.0",
             "esutils": "^2.0.2",
-            "lodash": "^4.17.4",
+            "lodash": "^4.17.21",
             "to-fast-properties": "^1.0.3"
           },
           "dependencies": {
@@ -14131,7 +14131,7 @@
         "glob": "^7.1.3",
         "immutable": "^4.0.0-rc.12",
         "io-ts": "1.10.4",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.21",
         "merkle-patricia-tree": "^4.2.2",
         "mnemonist": "^0.38.0",
         "mocha": "^9.2.0",
@@ -14562,7 +14562,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
         "figures": "^2.0.0",
-        "lodash": "^4.17.12",
+        "lodash": "^4.17.21",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.4.0",


### PR DESCRIPTION
`lodash` versions prior to 4.17.21 are vulnerable to Command Injection via the template function.

**CVE-2021-23337**
`7.2/ 10`
CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
