### PR TITLE
Encode the values passed in "poolData"

### DIFF
--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -401,6 +401,9 @@ export class TokenPoolEvent extends tokenEventBase {
   decimals: number;
 
   @ApiProperty()
+  poolData?: string;
+
+  @ApiProperty()
   info: TokenPoolEventInfo;
 }
 

--- a/src/tokens/tokens.service.spec.ts
+++ b/src/tokens/tokens.service.spec.ts
@@ -306,6 +306,7 @@ describe('TokensService', () => {
       };
 
       const response: TokenPoolEvent = {
+        poolData: 'ns1',
         poolLocator: ERC20_NO_DATA_POOL_ID,
         standard: 'ERC20',
         interfaceFormat: InterfaceFormat.ABI,
@@ -530,6 +531,7 @@ describe('TokensService', () => {
       };
 
       const response: TokenPoolEvent = {
+        poolData: 'ns1',
         poolLocator: ERC20_WITH_DATA_POOL_ID,
         standard: 'ERC20',
         interfaceFormat: InterfaceFormat.ABI,
@@ -723,6 +725,7 @@ describe('TokensService', () => {
       };
 
       const response: TokenPoolEvent = {
+        poolData: 'ns1',
         poolLocator: ERC721_NO_DATA_POOL_ID,
         standard: 'ERC721',
         interfaceFormat: InterfaceFormat.ABI,
@@ -931,6 +934,7 @@ describe('TokensService', () => {
       };
 
       const response: TokenPoolEvent = {
+        poolData: 'ns1',
         poolLocator: ERC721_WITH_DATA_POOL_ID,
         standard: 'ERC721',
         interfaceFormat: InterfaceFormat.ABI,

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -85,7 +85,7 @@ export class TokensService {
     this.topic = topic;
     this.factoryAddress = factoryAddress.toLowerCase();
     this.proxy.addConnectionListener(this);
-    this.proxy.addEventListener(new TokenListener(this, this.mapper, this.blockchain));
+    this.proxy.addEventListener(new TokenListener(this.mapper, this.blockchain));
   }
 
   async onConnect() {
@@ -380,6 +380,7 @@ export class TokensService {
 
     const poolInfo = await this.queryPool(ctx, poolLocator);
     const tokenPoolEvent: TokenPoolEvent = {
+      poolData: dto.poolData,
       poolLocator: dto.poolLocator,
       standard: poolLocator.type === TokenType.FUNGIBLE ? 'ERC20' : 'ERC721',
       interfaceFormat: InterfaceFormat.ABI,

--- a/src/tokens/tokens.util.spec.ts
+++ b/src/tokens/tokens.util.spec.ts
@@ -49,6 +49,9 @@ describe('Util', () => {
     ).toEqual(
       'fft:address=0x5bb034ca2fd1ac18e46978a7bbdbe4923e158d83&standard=ERC20WithData&type=fungible:mintWithData:ns1',
     );
+    expect(packSubscriptionName('0x123', 'create', 'ns1:test')).toEqual(
+      'fft:0x123:create:ns1%3Atest',
+    );
   });
 
   it('unpackSubscriptionName', () => {
@@ -66,6 +69,11 @@ describe('Util', () => {
       poolData: undefined,
       poolLocator: '0x123456',
       event: undefined,
+    });
+    expect(unpackSubscriptionName('fft:0x123:create:ns1%3Atest')).toEqual({
+      poolData: 'ns1:test',
+      poolLocator: '0x123',
+      event: 'create',
     });
   });
 

--- a/src/tokens/tokens.util.ts
+++ b/src/tokens/tokens.util.ts
@@ -44,7 +44,7 @@ export function decodeHex(data: string) {
 
 export function packSubscriptionName(poolLocator: string, event: string, poolData?: string) {
   if (poolData !== undefined) {
-    return [SUBSCRIPTION_PREFIX, poolLocator, event, poolData].join(':');
+    return [SUBSCRIPTION_PREFIX, poolLocator, event, encodeURIComponent(poolData)].join(':');
   }
   return [SUBSCRIPTION_PREFIX, poolLocator, event].join(':');
 }
@@ -55,7 +55,7 @@ export function unpackSubscriptionName(data: string) {
     return {
       poolLocator: parts[1],
       event: parts[2],
-      poolData: parts[3],
+      poolData: decodeURIComponent(parts[3]),
     };
   } else if (parts.length === 3) {
     return {


### PR DESCRIPTION
This ensures that the special character ":" (in particular) will be properly escaped.

Also, send "poolData" back in pool creation/activation events (instead of only in transfers/approvals).

See also https://github.com/hyperledger/firefly-tokens-erc1155/pull/119