### PR TITLE
High/Critical severity vuln checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,14 @@ RUN npm install
 ADD --chown=node:node ./samples/solidity .
 RUN npx hardhat compile
 
+FROM alpine:3.19 AS SBOM
+WORKDIR /
+ADD . /SBOM
+RUN apk add --no-cache curl 
+RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.48.3
+RUN trivy fs --format spdx-json --output /sbom.spdx.json /SBOM
+RUN trivy sbom /sbom.spdx.json --severity UNKNOWN,HIGH,CRITICAL --exit-code 1
+
 FROM node:16-alpine3.15
 RUN apk add curl jq
 RUN mkdir -p /app/contracts/source \
@@ -34,6 +42,7 @@ COPY --from=solidity-build --chown=1001:0 /home/node/artifacts/contracts/TokenFa
 WORKDIR /app
 COPY --from=build --chown=1001:0 /home/node/dist ./dist
 COPY --from=build --chown=1001:0 /home/node/package.json /home/node/package-lock.json ./
+COPY --from=SBOM /sbom.spdx.json /sbom.spdx.json
 
 RUN npm install --production
 EXPOSE 3000


### PR DESCRIPTION
This Pull request updates the Dockerfile to check dependencies of this source code, and fail to build if high/critical severity vulnerabilities are detected.

This is done with the help of Trivy, an open source scanning tool from Aquasec. Trivy is RedHat certified, and is being used as the default container scanner on GitLab (according [to this link](https://www.aquasec.com/products/trivy/))