### PR TITLE
Disconnect websocket from FireFly when WS from EVMConnect is disconnected

### DIFF
--- a/src/event-stream/event-stream.service.ts
+++ b/src/event-stream/event-stream.service.ts
@@ -51,6 +51,7 @@ export class EventStreamSocket {
     private password: string,
     private handleEvents: (events: EventBatch) => void,
     private handleReceipt: (receipt: EventStreamReply) => void,
+    private handleClose: () => void,
   ) {
     this.init();
   }
@@ -77,6 +78,7 @@ export class EventStreamSocket {
           this.logger.log('Event stream websocket closed');
         } else {
           this.disconnectDetected = true;
+          this.handleClose()
           this.logger.error(
             `Event stream websocket disconnected, attempting to reconnect in ${RECONNECT_TIME}ms`,
           );
@@ -357,6 +359,7 @@ export class EventStreamService {
     namespace: string,
     handleEvents: (events: EventBatch) => void,
     handleReceipt: (receipt: EventStreamReply) => void,
+    handleClose: () => void,
   ) {
     const name = eventStreamName(topic, namespace);
     await this.createOrUpdateStream(newContext(), name, topic);
@@ -369,6 +372,7 @@ export class EventStreamService {
       this.password,
       handleEvents,
       handleReceipt,
+      handleClose
     );
   }
 }

--- a/src/eventstream-proxy/eventstream-proxy.base.ts
+++ b/src/eventstream-proxy/eventstream-proxy.base.ts
@@ -107,6 +107,12 @@ export abstract class EventStreamProxyBase extends WebSocketEventsBase {
           receipt => {
             this.broadcast('receipt', <EventStreamReply>receipt);
           },
+          () => {
+            // When the connection is closed to EVMConnect
+            // Close the connection to FireFly as well
+            // FireFly will resend on connection the start event for the eventstreams we need to listen to
+            client.close()
+          }
         );
         this.namespaceEventStreamSocket.set(namespace, eventStreamSocket);
       }


### PR DESCRIPTION
This is to allow FireFly to resend which event streams we care about but it does force restart the namespace of FireFly! On the FireFly side if it gets a disconnect it will cancelCtx of the namespace.