### PR TITLE
Bump to Node 22

### DIFF
--- a/.github/workflows/docker_main.yml
+++ b/.github/workflows/docker_main.yml
@@ -27,8 +27,8 @@ jobs:
             --label commit=$GITHUB_SHA \
             --label build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
             --label tag=${{ steps.build_tag_generator.outputs.BUILD_TAG }} \
-            --build-arg BUILD_IMAGE=node:20-alpine3.17 \
-            --build-arg BASE_IMAGE=node:20-alpine3.17 \
+            --build-arg BUILD_IMAGE=node:22-alpine3.18 \
+            --build-arg BASE_IMAGE=node:22-alpine3.18 \
             --tag ghcr.io/hyperledger/firefly-tokens-erc20-erc721:${{ steps.build_tag_generator.outputs.BUILD_TAG }} .
 
       - name: Tag release

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -23,8 +23,8 @@ jobs:
             --label tag=${GITHUB_REF##*/} \
             --tag ghcr.io/hyperledger/firefly-tokens-erc20-erc721:${GITHUB_REF##*/} \
             --tag ghcr.io/hyperledger/firefly-tokens-erc20-erc721:head \
-            --build-arg BASE_IMAGE=node:20-alpine3.17 \
-            --build-arg BUILD_IMAGE=node:20-alpine3.17 \
+            --build-arg BASE_IMAGE=node:22-alpine3.18 \
+            --build-arg BUILD_IMAGE=node:22-alpine3.18 \
             .
 
       - name: Tag release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.9.0'
+          node-version: '22.15.0'
       - run: npm ci
       - run: npm run test
       - run: npm run test:e2e
@@ -23,7 +23,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.9.0'
+          node-version: '22.15.0'
       - run: npm ci
         working-directory: ./samples/solidity
       - run: npm run compile
@@ -35,4 +35,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Docker build
-        run: docker build --build-arg BASE_IMAGE=node:20-alpine3.17 --build-arg BUILD_IMAGE=node:20-alpine3.17 --tag ghcr.io/hyperledger/firefly-tokens-erc20-erc721 .
+        run: docker build --build-arg BASE_IMAGE=node:20-alpine3.17 --build-arg BUILD_IMAGE=node:22-alpine3.18 --tag ghcr.io/hyperledger/firefly-tokens-erc20-erc721 .


### PR DESCRIPTION
Node 18 is now end of life https://nodejs.org/en/about/previous-releases#release-schedule, upgrading to Node 22 LTS